### PR TITLE
Highlight agent reviews in collaborative reviews changelog

### DIFF
--- a/changelogs/2026-06-28__collaborative-reviews/index.mdx
+++ b/changelogs/2026-06-28__collaborative-reviews/index.mdx
@@ -11,7 +11,7 @@ image: /assets/changelogs/collaborative-reviews/collaborative-reviews.jpg
 
 Reviewing a build used to be a solo, one-shot decision — only the latest review counted, and there was nowhere to talk through what you were seeing. Reviews in Argos are now a place to collaborate. Request the people you need, leave comments pinned to exactly what changed, and resolve the discussion together — all updating in real time.
 
-Every reviewer's decision now counts on its own, so a build reflects the whole team's input instead of just the last person to weigh in.
+Every reviewer's decision now counts on its own, so a build reflects the whole team's input instead of just the last person to weigh in. And it's not just people: the CLI now exposes the full review toolkit, so AI agents can read a build, pin comments to the exact screenshots that changed, and submit a complete review — just like a human reviewer.
 
 - **Multiple reviewers** — request reviewers on a build and track each person's verdict individually, rather than overwriting it with the most recent one.
 - **Comment on exactly what changed** — pin a comment to a precise point on a screenshot, or to a line range inside a text-based snapshot.
@@ -23,7 +23,7 @@ Every reviewer's decision now counts on its own, so a build reflects the whole t
 
 Comments are written in Markdown with `/` slash commands and @mentions, drafts persist locally so you never lose a thought, and review notifications now arrive as a single digest instead of one per action.
 
-Learn more in the [reviewing a build documentation](https://argos-ci.com/docs/learn/review-workflow/review-a-build), or explore the [reviews](https://argos-ci.com/docs/api-reference/reference/reviews) and [comments](https://argos-ci.com/docs/api-reference/reference/comments) endpoints in the [REST API reference](https://argos-ci.com/docs/api-reference).
+Learn more in the [reviewing a build documentation](https://argos-ci.com/docs/learn/review-workflow/review-a-build), see how to [review builds with AI agents](https://argos-ci.com/docs/learn/review-workflow/review-builds-with-ai-agents), or explore the [reviews](https://argos-ci.com/docs/api-reference/reference/reviews) and [comments](https://argos-ci.com/docs/api-reference/reference/comments) endpoints in the [REST API reference](https://argos-ci.com/docs/api-reference).
 
 ## Configure what Argos ignores
 


### PR DESCRIPTION
## Summary

Highlights a key use case of collaborative reviews that the original changelog missed: AI agents can leverage the CLI to review builds — reading a build, pinning comments to the exact screenshots that changed, and submitting a complete review like a human reviewer.

- Calls this out directly in the feature description (intro), since it's an important use case
- Adds a link to the [Review builds with AI agents](https://argos-ci.com/docs/learn/review-workflow/review-builds-with-ai-agents) docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)