### PR TITLE
Move /docs proxy from next.config to middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const DOCS_PROXY = "https://proxy.gitbook.site/sites/site_S9wzD";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/docs" || pathname.startsWith("/docs/")) {
+    const rest = pathname.slice("/docs".length);
+    const url = new URL(DOCS_PROXY + rest + request.nextUrl.search);
+    console.log(`[middleware] rewriting ${pathname} -> ${url.toString()}`, {
+      headers: Object.fromEntries(request.headers),
+    });
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/docs", "/docs/:path*"],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -56,18 +56,6 @@ const nextConfig = {
       },
     ];
   },
-  rewrites: async () => {
-    return [
-      {
-        source: "/docs",
-        destination: "https://proxy.gitbook.site/sites/site_S9wzD",
-      },
-      {
-        source: "/docs/:path*",
-        destination: "https://proxy.gitbook.site/sites/site_S9wzD/:path*",
-      },
-    ];
-  },
   transpilePackages: ["next-mdx-remote", "geist"],
 };
 


### PR DESCRIPTION
## Summary
- Moves the `/docs` and `/docs/*` proxy rewrite out of `next.config.mjs` and into a new `middleware.ts`
- Rewrites to the GitBook proxy, preserving sub-path and query string
- Scopes execution to `/docs` paths via the `matcher` config
- Logs each rewrite (path → target) along with the request headers

## Notes
Middleware runs before `next.config.mjs` redirects/rewrites, but none of the remaining redirects touch `/docs`, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)