### PR TITLE
Fix "Domain not found" on /docs by pinning the GitBook resolution URL

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 const DOCS_PROXY = "https://proxy.gitbook.site/sites/site_S9wzD";
 
@@ -8,10 +8,16 @@ export function middleware(request: NextRequest) {
   if (pathname === "/docs" || pathname.startsWith("/docs/")) {
     const rest = pathname.slice("/docs".length);
     const url = new URL(DOCS_PROXY + rest + request.nextUrl.search);
-    console.log(`[middleware] rewriting ${pathname} -> ${url.toString()}`, {
-      headers: Object.fromEntries(request.headers),
-    });
-    return NextResponse.rewrite(url);
+
+    // Tell GitBook exactly which content URL to resolve via `x-gitbook-url`, its
+    // highest-priority signal. By default GitBook derives the content URL from
+    // `x-forwarded-host`, which Vercel sets to `argos-ci.com` on production requests;
+    // combined with the rewritten `/sites/<id>` path that resolves to "Domain not found".
+    // Setting the header makes resolution deterministic and independent of the forwarded host.
+    const headers = new Headers(request.headers);
+    headers.set("x-gitbook-url", url.toString());
+
+    return NextResponse.rewrite(url, { request: { headers } });
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Proposed changes

Some visitors hit **`Domain not found`** on `https://argos-ci.com/docs` (intermittently — it depended on the Vercel region and whether the response was cache-hit).

Our `/docs` middleware rewrites to `https://proxy.gitbook.site/sites/site_S9wzD/...`. GitBook, by default, derives the content URL it resolves from the `x-forwarded-host` header. On production requests Vercel sets that to `argos-ci.com`, so GitBook ended up resolving `https://argos-ci.com/sites/site_S9wzD` — which matches our custom-proxy **host** but not its expected `/docs` **path** — and returned `Domain not found`. On preview/`*.vercel.app` requests the forwarded host differed, which is why it "worked" there and hid the bug.

The fix sets **`x-gitbook-url`** (GitBook's highest-priority resolution signal) to the exact proxy URL we rewrite to. GitBook then resolves the site by its `/sites/<id>` path, deterministically, regardless of the forwarded host.

Verified against production GitBook:
- `x-gitbook-url: https://proxy.gitbook.site/sites/site_S9wzD` → **200**
- same, but with a forged `x-forwarded-host: argos-ci.com` → still **200** (proves `x-gitbook-url` wins)

Also removed the debug `console.log` that dumped all request headers (including the Vercel OIDC token).

## Changelog
- [Fix] Fix an intermittent "Domain not found" error when visiting the documentation at argos-ci.com/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)