### PR TITLE
Redirect /.well-known/* to app.argos-ci.com

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,11 @@ const nextConfig = {
   redirects: async () => {
     return [
       {
+        source: "/.well-known/:path*",
+        destination: "https://app.argos-ci.com/.well-known/:path*",
+        permanent: false,
+      },
+      {
         source: "/:organization/:repository/builds/:path*",
         destination:
           "https://app.argos-ci.com/:organization/:repository/builds/:path*",


### PR DESCRIPTION
## Summary

Redirects all `/.well-known/*` requests to `app.argos-ci.com`, preserving the sub-path.

This forwards resources like `security.txt`, `apple-app-site-association`, and `assetlinks.json` to the app domain.

## Details

- Added a redirect at the top of the `redirects` array in `next.config.mjs`.
- Uses `permanent: false` (307), matching the other external redirects — avoids client caching if the target changes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)