### PR TITLE
Replace logged-in redirect with opt-in "Open Argos" nudge

### DIFF
--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -24,35 +24,44 @@ import * as React from "react";
 import { ArgosLogo } from "@/components/ArgosLogo";
 import { Button } from "@/components/Button";
 import { Navbar } from "@/components/Navbar";
+import { OpenArgosButton } from "@/components/OpenArgosButton";
 import { ThemeImage, type ThemeImageProps } from "@/components/ThemeImage";
 import { type FeatureColor } from "@/components/feature-section/colors";
+import { useIsLoggedIn } from "@/components/session";
 
 import { cypress, playwright, storybook, wdio } from "./assets/brands/library";
 import { trackSignupClick } from "./google-ads";
 
 export const AppNavbar: React.FC = () => {
+  const loggedIn = useIsLoggedIn();
   return (
     <Navbar
       primary={
-        <NextLink href="/" className="inline-flex">
+        // Logged-in users point "home" to /homepage so navigating home never
+        // triggers the "/" → app redirect.
+        <NextLink href={loggedIn ? "/homepage" : "/"} className="inline-flex">
           <ArgosLogo className="h-6" />
         </NextLink>
       }
       secondary={<SecondaryNavbar />}
       actions={
-        <>
-          <Button variant="outline" asChild>
-            <a href="https://app.argos-ci.com/login">Login</a>
-          </Button>
-          <Button asChild>
-            <a
-              href="https://app.argos-ci.com/signup"
-              onClick={trackSignupClick}
-            >
-              Sign up
-            </a>
-          </Button>
-        </>
+        loggedIn ? (
+          <OpenArgosButton />
+        ) : (
+          <>
+            <Button variant="outline" asChild>
+              <a href="https://app.argos-ci.com/login">Login</a>
+            </Button>
+            <Button asChild>
+              <a
+                href="https://app.argos-ci.com/signup"
+                onClick={trackSignupClick}
+              >
+                Sign up
+              </a>
+            </Button>
+          </>
+        )
       }
     />
   );
@@ -296,9 +305,7 @@ function SectionTitle(props: {
 }) {
   const { children, className } = props;
   return (
-    <div
-      className={clsx("text-low mb-1 pl-2 text-xs uppercase", className)}
-    >
+    <div className={clsx("text-low mb-1 pl-2 text-xs uppercase", className)}>
       {children}
     </div>
   );

--- a/components/OpenArgosButton.tsx
+++ b/components/OpenArgosButton.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { clsx } from "clsx";
+import { ArrowRightIcon, XIcon } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/Button";
+import {
+  APP_URL,
+  dismissNudge,
+  getAlwaysOpen,
+  isNudgeDismissed,
+  openApp,
+  setAlwaysOpen,
+} from "@/components/session";
+
+/**
+ * Replaces the Login/Sign up actions for logged-in users. Renders an "Open Argos"
+ * button and, on desktop, a one-time dismissible nudge offering to always skip
+ * the marketing homepage. Choosing "Always open Argos" opts into the "/" → app
+ * redirect handled by {@link RedirectIfCookie}.
+ */
+export function OpenArgosButton() {
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+  const [showNudge, setShowNudge] = React.useState(false);
+
+  React.useEffect(() => {
+    // Desktop only: the mobile menu renders a second instance inside the burger
+    // dialog, and the desktop instance is `display:none` on mobile — skip both.
+    const isDesktop = window.matchMedia("(min-width: 768px)").matches;
+    const isVisible = anchorRef.current?.offsetParent != null;
+    if (!isDesktop || !isVisible) {
+      return;
+    }
+    if (getAlwaysOpen() || isNudgeDismissed()) {
+      return;
+    }
+    setShowNudge(true);
+  }, []);
+
+  const handleDismiss = React.useCallback(() => {
+    setShowNudge(false);
+    dismissNudge();
+  }, []);
+
+  const handleAlwaysOpen = React.useCallback(() => {
+    setAlwaysOpen();
+    openApp();
+  }, []);
+
+  // Dismiss on outside click / Escape while the nudge is open.
+  React.useEffect(() => {
+    if (!showNudge) {
+      return;
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      if (!anchorRef.current?.contains(event.target as Node)) {
+        handleDismiss();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        handleDismiss();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [showNudge, handleDismiss]);
+
+  return (
+    <div ref={anchorRef} className="relative">
+      <Button asChild>
+        <a href={APP_URL}>Open Argos</a>
+      </Button>
+      {showNudge ? (
+        <div
+          role="dialog"
+          aria-label="Always open Argos"
+          className={clsx(
+            "bg-app absolute top-full right-0 z-50 mt-2 w-72 rounded-lg p-4 text-left shadow-lg outline outline-(--neutral-6)",
+            "animate-in fade-in-0 slide-in-from-top-1 duration-200",
+          )}
+        >
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss"
+            className="text-low hover:text-default absolute top-3 right-3 transition"
+          >
+            <XIcon className="size-4" />
+          </button>
+          <p className="pr-6 text-sm font-medium">Skip this page next time?</p>
+          <button
+            type="button"
+            onClick={handleAlwaysOpen}
+            className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-(--primary-11) transition hover:underline"
+          >
+            Always open Argos
+            <ArrowRightIcon className="size-4" />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/RedirectIfCookie.tsx
+++ b/components/RedirectIfCookie.tsx
@@ -2,50 +2,25 @@
 
 import { useEffect } from "react";
 
-/**
- * Session flag set when the user explicitly opens `/homepage`. It opts the user
- * out of the "logged in → app" redirect for the rest of the browser session, so
- * logged-in users (and the team) can still browse the marketing site.
- */
-const STAY_KEY = "argos-stay-on-marketing";
+import { getAlwaysOpen, isLoggedIn, openApp } from "@/components/session";
 
 /**
- * Redirect logged-in users from the marketing homepage to the Argos app.
+ * Redirect logged-in users who opted into "Always open Argos" straight to the
+ * app — but only from the marketing root ("/"). Everywhere else (including
+ * "/homepage", which the navbar links to for logged-in users) they can browse
+ * the marketing site freely.
  *
- * Login is detected with the `argos_logged_in` hint cookie, a zero-privilege,
- * non-HttpOnly cookie Argos sets on the shared `.argos-ci.com` domain alongside
- * the real (HttpOnly) session cookie. Visiting `/homepage` opts out.
+ * The opt-in lives in localStorage and is set from the navbar's "Open Argos"
+ * popover. Login is detected with the non-HttpOnly `argos_logged_in` hint cookie
+ * Argos sets on the shared `.argos-ci.com` domain.
  */
 export function RedirectIfCookie() {
   useEffect(() => {
-    const { pathname } = window.location;
-
-    // Explicitly opening /homepage means "let me see the marketing site".
-    if (pathname === "/homepage") {
-      try {
-        window.sessionStorage.setItem(STAY_KEY, "1");
-      } catch {
-        // Ignore storage errors (private mode, disabled storage).
-      }
+    if (window.location.pathname !== "/") {
       return;
     }
-
-    if (pathname !== "/") {
-      return;
-    }
-
-    let stay = false;
-    try {
-      stay = window.sessionStorage.getItem(STAY_KEY) === "1";
-    } catch {
-      // Ignore storage errors.
-    }
-    if (stay) {
-      return;
-    }
-
-    if (document.cookie.includes("argos_logged_in=1")) {
-      window.location.href = "https://app.argos-ci.com/";
+    if (isLoggedIn() && getAlwaysOpen()) {
+      openApp();
     }
   }, []);
   return null;

--- a/components/session.ts
+++ b/components/session.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+export const APP_URL = "https://app.argos-ci.com/";
+
+/**
+ * Non-HttpOnly "hint" cookie the Argos app sets on the shared `.argos-ci.com`
+ * domain alongside the real (HttpOnly) session cookie. The marketing site only
+ * reads it to know whether someone is logged in.
+ */
+const LOGGED_IN_COOKIE = "argos_logged_in=1";
+
+/**
+ * Persisted opt-in ("Always open Argos"). When set, logged-in users are
+ * redirected from "/" straight to the app. Set from the navbar popover.
+ */
+const ALWAYS_OPEN_KEY = "argos-always-open-app";
+
+/** Persisted flag so the "Open Argos" nudge is only shown once. */
+const NUDGE_DISMISSED_KEY = "argos-open-argos-nudge-dismissed";
+
+export function isLoggedIn(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    document.cookie.includes(LOGGED_IN_COOKIE)
+  );
+}
+
+function readFlag(key: string): boolean {
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch {
+    // Ignore storage errors (private mode, disabled storage).
+    return false;
+  }
+}
+
+function writeFlag(key: string): void {
+  try {
+    window.localStorage.setItem(key, "1");
+  } catch {
+    // Ignore storage errors (private mode, disabled storage).
+  }
+}
+
+export const getAlwaysOpen = () => readFlag(ALWAYS_OPEN_KEY);
+export const setAlwaysOpen = () => writeFlag(ALWAYS_OPEN_KEY);
+
+export const isNudgeDismissed = () => readFlag(NUDGE_DISMISSED_KEY);
+export const dismissNudge = () => writeFlag(NUDGE_DISMISSED_KEY);
+
+export function openApp(): void {
+  window.location.href = APP_URL;
+}
+
+/**
+ * Returns `false` during SSR and the first client render, then `true` after
+ * mount when the user is logged in. Keeping the first client render in sync with
+ * the (logged-out) server markup avoids hydration mismatches.
+ */
+export function useIsLoggedIn(): boolean {
+  const [loggedIn, setLoggedIn] = React.useState(false);
+  React.useEffect(() => {
+    setLoggedIn(isLoggedIn());
+  }, []);
+  return loggedIn;
+}


### PR DESCRIPTION
## What & why

Gets rid of the aggressive "logged in → automatically redirect to app.argos-ci.com" behavior. Instead, logged-in users see the marketing site with an **Open Argos** button and an opt-in nudge (inspired by Notion, styled as Argos).

<img width="972" height="422" alt="CleanShot 2026-07-18 at 19 18 21@2x" src="https://github.com/user-attachments/assets/6c67f1d8-ab83-4a47-a59f-9679f63416ad" />


## Behavior

| State | Navbar | Landing on `/` |
|---|---|---|
| Logged out | Login + Sign up | stays |
| Logged in, not opted in | Open Argos + one-time nudge | **stays** (sees the site) |
| Logged in, opted in | Open Argos (no nudge) | redirects to app |

- The `/` → app redirect now fires **only from `/`** and **only** once the user chooses "Always open Argos" (persisted in `localStorage`).
- When logged in, the navbar logo links to `/homepage` instead of `/`, so navigating home never triggers the redirect (escape hatch).
- The nudge is desktop-only, dismissible (×), and shown once.
- Login detection is unchanged (the `argos_logged_in` hint cookie). The old `/homepage` `sessionStorage` opt-out is removed.

## Changes
- **New** `components/session.ts` — login detection + persisted "always open" / "nudge dismissed" flags + `useIsLoggedIn()` hook (SSR-safe).
- **New** `components/OpenArgosButton.tsx` — the button + Argos-styled auto-nudge.
- `components/RedirectIfCookie.tsx` — redirect only from `/`, only when logged in **and** opted in.
- `app/navbar.tsx` — swap Login/Sign up → Open Argos and logo `/` → `/homepage` when logged in.

## Verification
- `tsc --noEmit` passes; Prettier applied.
- Drove a real browser (Playwright) through all cases — logged-out, logged-in, opt-in click, dismiss, `/` vs `/homepage` vs `/pricing`, and mobile — 22/22 checks green.
- Confirmed the nudge renders as Argos (violet accent, `bg-app` surface) in light and dark.
- Existing Argos screenshot suite runs logged-out, so baselines are unaffected.

> Note: `pnpm lint` currently crashes repo-wide (pre-existing: `eslint-plugin-react@7.37.5` × `eslint@10.6.0`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)