### PR TITLE
Resolve navbar login-state blink before first paint

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,6 +90,17 @@ export default function RootLayout({
     >
       <GoogleTagManager gtmId="GTM-NLJR9K93" />
       <head>
+        {/*
+          Read the non-HttpOnly `argos_logged_in` hint cookie before first paint
+          and flag `<html>` so CSS can pick the logged-in vs logged-out navbar
+          without a hydration flash. Mirrors how next-themes sets the theme class.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "try{if(document.cookie.indexOf('argos_logged_in=1')>-1)document.documentElement.classList.add('argos-authed')}catch(e){}",
+          }}
+        />
         <PlausibleProvider src="https://plausible.io/js/pa-MUtv2DPAT8fCOLi_QqcGL.js" />
         <GoogleAdsScripts />
       </head>

--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -27,28 +27,32 @@ import { Navbar } from "@/components/Navbar";
 import { OpenArgosButton } from "@/components/OpenArgosButton";
 import { ThemeImage, type ThemeImageProps } from "@/components/ThemeImage";
 import { type FeatureColor } from "@/components/feature-section/colors";
-import { useIsLoggedIn } from "@/components/session";
 
 import { cypress, playwright, storybook, wdio } from "./assets/brands/library";
 import { trackSignupClick } from "./google-ads";
 
 export const AppNavbar: React.FC = () => {
-  const loggedIn = useIsLoggedIn();
   return (
     <Navbar
       primary={
-        // Logged-in users point "home" to /homepage so navigating home never
-        // triggers the "/" → app redirect.
-        <NextLink href={loggedIn ? "/homepage" : "/"} className="inline-flex">
-          <ArgosLogo className="h-6" />
-        </NextLink>
+        // Both logos are rendered; CSS shows the one matching the login state
+        // (flagged pre-paint on <html>). Logged-in users point "home" to
+        // /homepage so navigating home never triggers the "/" → app redirect.
+        <>
+          <NextLink data-when-guest href="/" className="inline-flex">
+            <ArgosLogo className="h-6" />
+          </NextLink>
+          <NextLink data-when-authed href="/homepage" className="inline-flex">
+            <ArgosLogo className="h-6" />
+          </NextLink>
+        </>
       }
       secondary={<SecondaryNavbar />}
       actions={
-        loggedIn ? (
-          <OpenArgosButton />
-        ) : (
-          <>
+        // Both action sets are rendered; CSS hides the one that doesn't apply.
+        // `contents` wrappers keep the buttons in the parent flex layout.
+        <>
+          <div data-when-guest className="contents">
             <Button variant="outline" asChild>
               <a href="https://app.argos-ci.com/login">Login</a>
             </Button>
@@ -60,8 +64,11 @@ export const AppNavbar: React.FC = () => {
                 Sign up
               </a>
             </Button>
-          </>
-        )
+          </div>
+          <div data-when-authed className="contents">
+            <OpenArgosButton />
+          </div>
+        </>
       }
     />
   );

--- a/components/session.ts
+++ b/components/session.ts
@@ -1,7 +1,5 @@
 "use client";
 
-import * as React from "react";
-
 export const APP_URL = "https://app.argos-ci.com/";
 
 /**
@@ -52,17 +50,4 @@ export const dismissNudge = () => writeFlag(NUDGE_DISMISSED_KEY);
 
 export function openApp(): void {
   window.location.href = APP_URL;
-}
-
-/**
- * Returns `false` during SSR and the first client render, then `true` after
- * mount when the user is logged in. Keeping the first client render in sync with
- * the (logged-out) server markup avoids hydration mismatches.
- */
-export function useIsLoggedIn(): boolean {
-  const [loggedIn, setLoggedIn] = React.useState(false);
-  React.useEffect(() => {
-    setLoggedIn(isLoggedIn());
-  }, []);
-  return loggedIn;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -477,3 +477,13 @@
     }
   }
 }
+
+/*
+  Logged-in-aware UI. Both variants are rendered server-side; the pre-paint
+  script in <head> flags `<html>` with `argos-authed`, so we only ever hide the
+  variant that doesn't apply. Shown elements keep their own display value.
+*/
+html:not(.argos-authed) [data-when-authed],
+html.argos-authed [data-when-guest] {
+  display: none !important;
+}


### PR DESCRIPTION
## Problem

The logged-in navbar (logo target + "Open Argos" button) was resolved client-side via `useIsLoggedIn()`, so the server shipped the logged-out markup and the correct variant only swapped in after hydration — a visible blink for logged-in visitors.

## Approach

Kill the flash **without** giving up static rendering (reading `cookies()` in the root layout would force the whole site dynamic):

- A tiny blocking `<script>` in `<head>` reads the non-HttpOnly `argos_logged_in` hint cookie and flags `<html>` with `argos-authed` **before first paint** — the same technique next-themes already uses for the theme class.
- The navbar now renders **both** variants server-side (`data-when-guest` / `data-when-authed`); one CSS rule hides whichever doesn't apply. `contents` wrappers keep the buttons in the parent flex layout.
- Removed the now-unused `useIsLoggedIn` hook. `isLoggedIn()` stays (still used by `RedirectIfCookie` and `OpenArgosButton`).

## Notes

- Site stays 100% statically generated — no CDN/SEO regression.
- The "Always open Argos" nudge still behaves correctly: `OpenArgosButton` is always in the DOM but its effect already bails when `offsetParent == null` (true under `display:none`), so guests never trigger it.
- `<html>` already has `suppressHydrationWarning`, so the pre-paint class doesn't warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)