### PR TITLE
fix(navbar): make mobile nav dropdowns scrollable when clipped

### DIFF
--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -292,7 +292,7 @@ function SecondaryNavbar() {
             ["--easing" as string]: "cubic-bezier(0.22, 1, 0.36, 1)",
           }}
         >
-          <NavigationMenu.Popup className="data-[ending-style]:easing-[ease] xs:w-[var(--popup-width)] relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden rounded-lg bg-[canvas] shadow-lg/8 outline outline-(--neutral-6) transition-[opacity,transform,width,height,scale,translate] duration-(--duration) ease-(--easing) data-ending-style:scale-90 data-ending-style:opacity-0 data-ending-style:duration-150 data-starting-style:scale-90 data-starting-style:opacity-0">
+          <NavigationMenu.Popup className="data-[ending-style]:easing-[ease] xs:w-[var(--popup-width)] relative h-(--popup-height) max-h-(--available-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden rounded-lg bg-[canvas] shadow-lg/8 outline outline-(--neutral-6) transition-[opacity,transform,width,height,scale,translate] duration-(--duration) ease-(--easing) data-ending-style:scale-90 data-ending-style:opacity-0 data-ending-style:duration-150 data-starting-style:scale-90 data-starting-style:opacity-0">
             <NavigationMenu.Viewport className="relative h-full w-full overflow-hidden" />
           </NavigationMenu.Popup>
         </NavigationMenu.Positioner>
@@ -342,7 +342,7 @@ const navIconClassName = clsx(
 );
 
 const contentClassName = clsx(
-  "h-full bg-app z-40",
+  "h-full bg-app z-40 overflow-y-auto overscroll-contain",
   "transition-[opacity,transform,translate] duration-(--duration) ease-(--easing)",
   "data-starting-style:opacity-0 data-ending-style:opacity-0",
   "data-starting-style:data-[activation-direction=left]:translate-x-[-50%]",

--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -342,7 +342,9 @@ const navIconClassName = clsx(
 );
 
 const contentClassName = clsx(
-  "h-full bg-app z-40 overflow-y-auto overscroll-contain",
+  // Clamp the content itself: when --popup-height is `auto` (prod), the
+  // popup height is indefinite so `h-full` can't resolve against it.
+  "h-full max-h-(--available-height) bg-app z-40 overflow-y-auto overscroll-contain",
   "transition-[opacity,transform,translate] duration-(--duration) ease-(--easing)",
   "data-starting-style:opacity-0 data-ending-style:opacity-0",
   "data-starting-style:data-[activation-direction=left]:translate-x-[-50%]",


### PR DESCRIPTION
Fixes [ARG-474](https://linear.app/argos/issue/ARG-474)

On mobile, tapping **Product** or **Resources** in the burger menu opened a dropdown whose bottom items were unreachable — the popup's height was pinned to its content's natural height with `overflow-hidden` everywhere, so tall menus just clipped past the viewport.

## Fix

- Cap the `NavigationMenu.Popup` height with `max-h-(--available-height)` (the CSS variable Base UI already exposes on the Positioner).
- Add `overflow-y-auto overscroll-contain` to the menu content so it scrolls inside the clamped popup.

## Verified

Playwright on an iPhone 13 viewport: the Product dropdown now clamps to the viewport, scrolls, and the last item (WebdriverIO) is reachable and clickable — clicking it navigates to the quickstart. Desktop hover menus unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)