### PR TITLE
fix(blog): don't link to articles that aren't published yet

### DIFF
--- a/lib/api/blog.tsx
+++ b/lib/api/blog.tsx
@@ -11,6 +11,7 @@ import {
 import { MainImage } from "@/components/Post";
 
 import { assertAllItems, getDocMdxSource, readMatterData } from "./common";
+import { checkIsPublished, showScheduledContent } from "./schedule";
 
 const authorSlugSchema = z.enum(["greg", "jeremy"]);
 
@@ -72,22 +73,6 @@ const FrontmatterSchema = z.object({
 
 export type Frontmatter = z.infer<typeof FrontmatterSchema>;
 
-/**
- * Scheduled articles (publish date in the future) are hidden from the
- * production build. They stay visible in dev and on Vercel preview
- * deployments so they can be reviewed before their release. A daily
- * GitHub Actions cron redeploys the site to reveal articles whose
- * publish date has elapsed (see .github/workflows/publish-scheduled-articles.yml).
- */
-const showScheduledArticles =
-  process.env.NODE_ENV === "development" ||
-  process.env.VERCEL_ENV === "preview" ||
-  process.env.SHOW_SCHEDULED_ARTICLES === "true";
-
-function checkIsPublished(frontmatter: { date: string }): boolean {
-  return new Date(frontmatter.date) <= new Date();
-}
-
 export type Article = Omit<Frontmatter, "image" | "author" | "category"> & {
   image: StaticImageData;
   filepath: string;
@@ -145,9 +130,9 @@ export async function getArticles(filters?: {
     );
   }
   assertAllItems(articles);
-  const publishedArticles = showScheduledArticles
+  const publishedArticles = showScheduledContent
     ? articles
-    : articles.filter(checkIsPublished);
+    : articles.filter((article) => checkIsPublished(article.date));
   return publishedArticles.sort(
     (a, b) => Number(new Date(b.date)) - Number(new Date(a.date)),
   );
@@ -192,7 +177,7 @@ export function getArticlesPagesCount(nbArticles: number) {
 export async function getArticleBySlug(slug: string): Promise<Article | null> {
   const filepath = `./articles/${slug}/index.mdx`;
   const article = await getArticleDataFromPath(filepath);
-  if (article && !showScheduledArticles && !checkIsPublished(article)) {
+  if (article && !showScheduledContent && !checkIsPublished(article.date)) {
     return null;
   }
   return article;

--- a/lib/api/changelog.tsx
+++ b/lib/api/changelog.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Zoom } from "@/components/Zoom";
 
 import { assertAllItems, getDocMdxSource, readMatterData } from "./common";
+import { checkIsPublished, showScheduledContent } from "./schedule";
 
 const PAGE_SIZE = 10;
 
@@ -68,16 +69,11 @@ async function getChangelogFromPath(
 /**
  * Scheduled changelog entries (date in the future) are hidden from the
  * production build, following the same rules as scheduled blog articles
- * (see blog.tsx). The date is read from the folder name (YYYY-MM-DD__slug).
+ * (see schedule.ts). The date is read from the folder name (YYYY-MM-DD__slug).
  */
-const showScheduledEntries =
-  process.env.NODE_ENV === "development" ||
-  process.env.VERCEL_ENV === "preview" ||
-  process.env.SHOW_SCHEDULED_ARTICLES === "true";
-
-function checkIsPublished(filepath: string): boolean {
+function checkIsEntryPublished(filepath: string): boolean {
   const match = filepath.match(/\/(\d{4}-\d{2}-\d{2})__/);
-  return !match || new Date(match[1]) <= new Date();
+  return !match || checkIsPublished(match[1]);
 }
 
 /**
@@ -85,9 +81,9 @@ function checkIsPublished(filepath: string): boolean {
  */
 export async function getChangelogFiles() {
   const allFiles = await fg("./changelogs/**/*.mdx");
-  const files = showScheduledEntries
+  const files = showScheduledContent
     ? allFiles
-    : allFiles.filter(checkIsPublished);
+    : allFiles.filter(checkIsEntryPublished);
   files.sort((a, b) => b.localeCompare(a));
   return files;
 }
@@ -135,7 +131,7 @@ export async function getChangelogEntryBySlug(
   const date = urlSlug.split("-").slice(0, 3).join("-");
   const slug = urlSlug.split("-").slice(3).join("-");
   const filepath = `./changelogs/${date}__${slug}/index.mdx`;
-  if (!showScheduledEntries && !checkIsPublished(filepath)) {
+  if (!showScheduledContent && !checkIsEntryPublished(filepath)) {
     return null;
   }
   return getChangelogFromPath(filepath);

--- a/lib/api/common.tsx
+++ b/lib/api/common.tsx
@@ -2,10 +2,13 @@ import rehypeShiki from "@shikijs/rehype";
 import * as matter from "gray-matter";
 import { MDXRemoteProps, compileMDX } from "next-mdx-remote/rsc";
 import { readFile } from "node:fs/promises";
+import type { ComponentProps } from "react";
 import rehypeImgSize from "rehype-img-size";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import { ZodType, type output } from "zod";
+
+import { getScheduledPaths } from "./schedule";
 
 /**
  * Read the frontmatter data from a file.
@@ -25,6 +28,42 @@ export function readMatterData<T extends ZodType>(
   }
 }
 
+const SITE_URL = "https://argos-ci.com";
+
+/**
+ * Get the pathname of an internal link, or `null` if the href points somewhere
+ * else (external site, anchor, mailto, …).
+ */
+function getInternalPathname(href: string): string | null {
+  const path = href.startsWith(`${SITE_URL}/`)
+    ? href.slice(SITE_URL.length)
+    : href;
+  if (!path.startsWith("/")) {
+    return null;
+  }
+  return path.replace(/[?#].*$/, "").replace(/\/$/, "");
+}
+
+/**
+ * Anchor used for links in MDX content. Links pointing to content that is not
+ * published yet are rendered as plain text instead of a link to a 404. They
+ * become real links again on their own once the publish date has elapsed and the
+ * site is rebuilt (see `getScheduledPaths`).
+ */
+function createMdxAnchor(scheduledPaths: ReadonlySet<string>) {
+  return function MdxAnchor({ href, children, ...props }: ComponentProps<"a">) {
+    const pathname = href ? getInternalPathname(href) : null;
+    if (pathname && scheduledPaths.has(pathname)) {
+      return <>{children}</>;
+    }
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+}
+
 /**
  * Get the MDX source of a MDX file.
  */
@@ -33,10 +72,13 @@ export async function getDocMdxSource(
   options: Pick<MDXRemoteProps, "components"> &
     Pick<NonNullable<MDXRemoteProps["options"]>, "scope">,
 ) {
-  const source = await readFile(filepath, "utf-8");
+  const [source, scheduledPaths] = await Promise.all([
+    readFile(filepath, "utf-8"),
+    getScheduledPaths(),
+  ]);
   const result = await compileMDX({
     source,
-    components: options.components,
+    components: { a: createMdxAnchor(scheduledPaths), ...options.components },
     options: {
       scope: options.scope,
       blockJS: false,

--- a/lib/api/schedule.ts
+++ b/lib/api/schedule.ts
@@ -1,0 +1,61 @@
+import fg from "fast-glob";
+import * as matter from "gray-matter";
+
+/**
+ * Scheduled content (publish date in the future) is hidden from the production
+ * build. It stays visible in dev and on Vercel preview deployments so it can be
+ * reviewed before its release. A daily GitHub Actions cron redeploys the site to
+ * reveal content whose publish date has elapsed
+ * (see .github/workflows/publish-scheduled-articles.yml).
+ */
+export const showScheduledContent =
+  process.env.NODE_ENV === "development" ||
+  process.env.VERCEL_ENV === "preview" ||
+  process.env.SHOW_SCHEDULED_ARTICLES === "true";
+
+/**
+ * Check if a publish date has elapsed.
+ */
+export function checkIsPublished(date: string | Date): boolean {
+  return new Date(date) <= new Date();
+}
+
+let scheduledPathsPromise: Promise<ReadonlySet<string>> | null = null;
+
+/**
+ * Pathnames of the content that is not part of this build because its publish
+ * date has not elapsed yet. Used to unlink references to it in MDX content
+ * (see `getDocMdxSource`), so we never ship a link to a 404.
+ */
+export function getScheduledPaths(): Promise<ReadonlySet<string>> {
+  scheduledPathsPromise ??= readScheduledPaths();
+  return scheduledPathsPromise;
+}
+
+async function readScheduledPaths(): Promise<ReadonlySet<string>> {
+  if (showScheduledContent) {
+    return new Set();
+  }
+  const [articleFiles, changelogFiles] = await Promise.all([
+    fg("./articles/**/*.mdx"),
+    fg("./changelogs/**/*.mdx"),
+  ]);
+  const paths = new Set<string>();
+  for (const filepath of articleFiles) {
+    const { date } = matter.read(filepath).data;
+    if (date && !checkIsPublished(date)) {
+      const slug = filepath
+        .replace(/^\.\/articles\//, "")
+        .replace(/\/index\.mdx$/, "");
+      paths.add(`/blog/${slug}`);
+    }
+  }
+  for (const filepath of changelogFiles) {
+    // Changelog entries carry their date in the folder name (YYYY-MM-DD__slug).
+    const match = filepath.match(/\/(\d{4}-\d{2}-\d{2})__([^/]+)\//);
+    if (match && !checkIsPublished(match[1])) {
+      paths.add(`/changelog/${match[1]}-${match[2]}`);
+    }
+  }
+  return paths;
+}


### PR DESCRIPTION
An Ahrefs crawl reported 404 internal links from published articles. The targets exist, but their publish date is in the future, so the [scheduled-content filter](https://github.com/argos-ci/argos-ci.com/blob/main/lib/api/schedule.ts) keeps them out of the production build: `ai-visual-testing` (2026-08-20), `visual-testing-pricing` (2026-08-11), `backstopjs-alternative` (2026-08-25). Meanwhile the articles linking to them ship with live `href`s.

## Changes

- **`lib/api/schedule.ts`** (new): the scheduling rules, until now duplicated in `blog.tsx` and `changelog.tsx` — `showScheduledContent`, `checkIsPublished(date)`, and a cached `getScheduledPaths()` returning the pathnames excluded from this build (`/blog/<slug>` from article frontmatter dates, `/changelog/<date>-<slug>` from folder names).
- **`lib/api/common.tsx`**: `getDocMdxSource` injects a default `a` component for all MDX (articles, changelogs, customer cases). It normalizes the href to a pathname — handling absolute `https://argos-ci.com/…` URLs, query strings and trailing slashes — and renders the link's children as plain text when that pathname is scheduled. Callers can still override `a`.

Rendering happens at build time and the daily cron already redeploys once a publish date elapses, so each link turns back into a real link on its own. No content edits needed.

## Notes

- A link to a slug that doesn't exist at all is left untouched: silently unlinking typos would hide genuinely broken links from crawls, whereas this only suppresses links whose target is on the way.
- Dev and Vercel previews show scheduled content, so the set is empty there and links stay clickable while reviewing.
- `storybook-visual-testing-without-chromatic` is dated 2026-07-30, so it is published and its links correctly stayed active — that CSV row is already resolved.

## Test plan

- `pnpm build` (scheduled filter active): zero prerendered `href` to any of the three unpublished slugs, anchor text still present in the prose — e.g. "visual testing pricing guide" in `percy-vs-chromatic-vs-argos` is now plain text. Internal and external links elsewhere render unchanged.
- `pnpm check-types`, `eslint`, `prettier --check`, `knip`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)