### PR TITLE
feat(home): add a collaborative reviews section

### DIFF
--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -1,7 +1,6 @@
 import { MapPinIcon, SparklesIcon, UserPlusIcon } from "lucide-react";
 import Link from "next/link";
 
-import { leMondeReviewsQuote } from "@/app/assets/customers/library/le-monde";
 import { Button } from "@/components/Button";
 import { Container } from "@/components/Container";
 import { SectionHeader, SectionHeaderTexts } from "@/components/SectionHeader";
@@ -66,10 +65,10 @@ export function CollaborativeReviews() {
             </li>
           ))}
         </ul>
-        <CustomerStory
-          color="pink"
-          story={{ quote: leMondeReviewsQuote, href: "/customers/lemonde" }}
-        />
+        {/* No story yet: Le Monde already speaks under test debugging, and a
+            second quote from the same customer on one page reads as thin.
+            Waiting on an approved quote from another customer. */}
+        <CustomerStory color="pink" />
         <div className="h-12 border-t" />
       </Container>
     </div>

--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -25,7 +25,7 @@ const FEATURES = [
   {
     icon: SparklesIcon,
     title: "Your agent takes it from there",
-    text: "Hit Handle with AI to let your agent take over. The fix lands in the next commit.",
+    text: "Send the thread to your agent, straight into your editor. The fix lands in the next commit",
   },
 ];
 

--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -66,10 +66,6 @@ export function CollaborativeReviews() {
             </li>
           ))}
         </ul>
-        <CustomerStory
-          color="pink"
-          story={{ quote: leMondeReviewsQuote, href: "/customers/lemonde" }}
-        />
         <div className="h-12 border-t" />
       </Container>
     </div>

--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -1,0 +1,77 @@
+import { MapPinIcon, SparklesIcon, UserPlusIcon } from "lucide-react";
+import Link from "next/link";
+
+import { leMondeReviewsQuote } from "@/app/assets/customers/library/le-monde";
+import { Button } from "@/components/Button";
+import { Container } from "@/components/Container";
+import { SectionHeader, SectionHeaderTexts } from "@/components/SectionHeader";
+import { SectionDescription, SectionTitle } from "@/components/Typography";
+import { CustomerStory } from "@/components/feature-section/CustomerStory";
+import { FeatureIndicator } from "@/components/feature-section/FeatureSection";
+
+import { ReviewCanvas } from "./ReviewCanvas";
+
+const FEATURES = [
+  {
+    icon: MapPinIcon,
+    title: "Pin your comment",
+    text: "Click on a pixel and start the conversation right there. Everyone follows along.",
+  },
+  {
+    icon: UserPlusIcon,
+    title: "Bring the reviewers you need",
+    text: "Add the designer, the feature owner, whoever you want. Every review counts.",
+  },
+  {
+    icon: SparklesIcon,
+    title: "Your agent takes it from there",
+    text: "Hit Handle with AI to let your agent take over. The fix lands in the next commit.",
+  },
+];
+
+export function CollaborativeReviews() {
+  return (
+    <div className="separator-b relative px-4">
+      <Container className="border-x" noGutter>
+        <SectionHeader className="container-gutter pb-8 md:pb-10">
+          <SectionHeaderTexts>
+            <FeatureIndicator color="pink">
+              Collaborative Reviews
+            </FeatureIndicator>
+            <SectionTitle>Keep your team on the same page</SectionTitle>
+            <SectionDescription className="max-w-2xl">
+              Your team and your agents review together, right on the change.
+            </SectionDescription>
+          </SectionHeaderTexts>
+          <Button variant="outline" asChild>
+            <Link href="/collaborative-reviews">
+              Explore Collaborative Reviews
+            </Link>
+          </Button>
+        </SectionHeader>
+        <div className="border-t border-b px-4 py-10 md:px-10 md:py-16">
+          <ReviewCanvas />
+        </div>
+        <ul className="grid divide-y border-b md:grid-cols-3 md:divide-x md:divide-y-0">
+          {FEATURES.map((point) => (
+            <li key={point.title} className="flex gap-4 p-6 md:p-8">
+              <point.icon
+                className="mt-0.5 size-5 shrink-0 text-(--pink-11)"
+                strokeWidth={1.5}
+              />
+              <div>
+                <h3 className="font-accent font-medium">{point.title}</h3>
+                <p className="text-low text-sm">{point.text}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <CustomerStory
+          color="pink"
+          story={{ quote: leMondeReviewsQuote, href: "/customers/lemonde" }}
+        />
+        <div className="h-12 border-t" />
+      </Container>
+    </div>
+  );
+}

--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -49,7 +49,7 @@ export function CollaborativeReviews() {
             </Link>
           </Button>
         </SectionHeader>
-        <div className="border-t border-b px-4 py-10 md:px-10 md:py-16">
+        <div className="bg-subtle border-t border-b px-4 py-8 md:px-10 md:py-10">
           <ReviewCanvas />
         </div>
         <ul className="grid divide-y border-b md:grid-cols-3 md:divide-x md:divide-y-0">

--- a/app/home/collaborative-reviews/CollaborativeReviews.tsx
+++ b/app/home/collaborative-reviews/CollaborativeReviews.tsx
@@ -1,6 +1,7 @@
 import { MapPinIcon, SparklesIcon, UserPlusIcon } from "lucide-react";
 import Link from "next/link";
 
+import { leMondeReviewsQuote } from "@/app/assets/customers/library/le-monde";
 import { Button } from "@/components/Button";
 import { Container } from "@/components/Container";
 import { SectionHeader, SectionHeaderTexts } from "@/components/SectionHeader";
@@ -65,10 +66,10 @@ export function CollaborativeReviews() {
             </li>
           ))}
         </ul>
-        {/* No story yet: Le Monde already speaks under test debugging, and a
-            second quote from the same customer on one page reads as thin.
-            Waiting on an approved quote from another customer. */}
-        <CustomerStory color="pink" />
+        <CustomerStory
+          color="pink"
+          story={{ quote: leMondeReviewsQuote, href: "/customers/lemonde" }}
+        />
         <div className="h-12 border-t" />
       </Container>
     </div>

--- a/app/home/collaborative-reviews/ReviewCanvas.tsx
+++ b/app/home/collaborative-reviews/ReviewCanvas.tsx
@@ -1,5 +1,10 @@
 import clsx from "clsx";
-import { CheckIcon, GitPullRequestArrowIcon, XIcon } from "lucide-react";
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  GitPullRequestArrowIcon,
+  XIcon,
+} from "lucide-react";
 
 import { andrewAvatar, ninaAvatar } from "@/app/assets/people/library";
 import { ApplicationSVG } from "@/components/ApplicationSVG";
@@ -141,17 +146,21 @@ const ACTIVITY: ActivityEvent[] = [
     avatar: andrewAvatar,
     kind: "approved",
     action: "approved",
-    time: "14m ago",
+    time: "5m ago",
   },
   {
     name: "Nina",
     avatar: ninaAvatar,
     kind: "changes",
     action: "requested changes",
-    time: "4m ago",
-    comment: "This card shifted 4px right, the total is cut off.",
-    pin: 1,
-    reactions: "👍 2",
+    time: "2m ago",
+    comment: (
+      <>
+        <span className="text-(--violet-11)">@Andrew</span> Price tag is hidden
+        on mobile
+      </>
+    ),
+    reactions: "👍 1",
   },
   {
     name: "Andrew",
@@ -183,6 +192,14 @@ function Activity() {
           />
         ))}
       </ol>
+      {/* Pinned to the bottom: the rail is short next to two screenshot panes,
+          and the composer is what says the thread is still open. */}
+      <div className="mt-auto flex items-center gap-2 border-t-[0.5px] px-3 py-2">
+        <span className="text-subtle text-xs">Leave a reply…</span>
+        <span className="ml-auto grid size-5 shrink-0 place-items-center rounded-full border-[0.5px]">
+          <ArrowUpIcon className="text-low size-3" />
+        </span>
+      </div>
     </div>
   );
 }
@@ -223,7 +240,7 @@ function ActivityRow(props: { event: ActivityEvent; last: boolean }) {
         <div className="flex flex-wrap items-baseline gap-x-1.5">
           <span className="text-xs font-medium">{event.name}</span>
           <span className={clsx("text-xs", kind.text)}>{event.action}</span>
-          <span className="text-low text-xxs">{event.time}</span>
+          <span className="text-low text-xxs"> • {event.time}</span>
         </div>
         {event.comment ? (
           <p className="text-low mt-1 text-xs">
@@ -232,7 +249,9 @@ function ActivityRow(props: { event: ActivityEvent; last: boolean }) {
           </p>
         ) : null}
         {event.reactions ? (
-          <Badge className="mt-1.5">{event.reactions}</Badge>
+          <div className="text-xxs mt-1.5 inline-flex items-center gap-1 rounded-lg bg-(--neutral-3) px-2 py-0.5 font-medium text-(--neutral-11)">
+            {event.reactions}
+          </div>
         ) : null}
       </div>
     </li>

--- a/app/home/collaborative-reviews/ReviewCanvas.tsx
+++ b/app/home/collaborative-reviews/ReviewCanvas.tsx
@@ -1,0 +1,259 @@
+import clsx from "clsx";
+import { CheckIcon, GitPullRequestArrowIcon, XIcon } from "lucide-react";
+
+import { andrewAvatar, ninaAvatar } from "@/app/assets/people/library";
+import { ApplicationSVG } from "@/components/ApplicationSVG";
+import { Badge } from "@/components/Badge";
+import { Card } from "@/components/Card";
+import { DotIndicator } from "@/components/DotIndicator";
+import { ThemeImage, type ThemeImageProps } from "@/components/ThemeImage";
+import { SmallTitle } from "@/components/Typography";
+
+export function ReviewCanvas() {
+  return (
+    <Card
+      shadow="high"
+      className="animate-fade-in-up motion-reduce:animate-fade-in animate-duration-500 fill-mode-both mx-auto w-full max-w-4xl overflow-hidden"
+    >
+      <Toolbar />
+      <div className="grid md:grid-cols-[1fr_17rem]">
+        <Panes />
+        <Activity />
+      </div>
+    </Card>
+  );
+}
+
+function Toolbar() {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b-[0.5px] px-3 py-2">
+      <SmallTitle className="min-w-0">
+        <GitPullRequestArrowIcon className="size-3.5 shrink-0 text-(--pink-11)" />
+        <span className="truncate">checkout-summary</span>
+        <span className="text-low shrink-0">#482</span>
+      </SmallTitle>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge className="text-xxs gap-1.5 border-(--danger-7) text-(--danger-11) max-sm:hidden">
+          <DotIndicator variant="danger" />
+          Changes requested
+        </Badge>
+        <div className="flex -space-x-1.5">
+          <Avatar src={andrewAvatar} />
+          <Avatar src={ninaAvatar} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Panes() {
+  return (
+    <div className="bg-subtle grid grid-cols-2 gap-3 p-4 max-md:border-b-[0.5px] md:gap-4 md:border-r-[0.5px] md:p-6">
+      <Pane tone="baseline" />
+      <Pane tone="changes" />
+    </div>
+  );
+}
+
+function Pane(props: { tone: "baseline" | "changes" }) {
+  const { tone } = props;
+  const isChanges = tone === "changes";
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div
+        className={clsx(
+          "text-xxs inline-flex items-center justify-center gap-1.5 rounded-lg border-[0.5px] py-0.5 font-semibold md:py-1",
+          isChanges ? "border-(--danger-6)" : "border-(--neutral-6)",
+        )}
+      >
+        <DotIndicator variant={isChanges ? "danger" : "neutral"} />
+        {isChanges ? "Changes" : "Baseline"}
+      </div>
+      <div className="relative">
+        <ApplicationSVG withChanges={isChanges} className="w-full" />
+        {isChanges ? <Pin /> : null}
+      </div>
+    </div>
+  );
+}
+
+function Pin() {
+  return (
+    <span
+      className="absolute -translate-x-1/2 -translate-y-1/2"
+      style={{ left: "50%", top: "73%" }}
+      aria-hidden
+    >
+      <span className="absolute inset-0 animate-ping rounded-full bg-(--pink-9) opacity-40" />
+      <span className="text-xxs relative grid size-5 place-items-center rounded-full bg-(--pink-9) font-semibold text-white shadow-md/20 ring-2 ring-(--neutral-1)">
+        1
+      </span>
+    </span>
+  );
+}
+
+/**
+ * What each kind of event puts on the rail.
+ *
+ * The verdicts get a coloured chip on the avatar, a comment gets none: the
+ * missing chip is what tells the eye a reply is not a decision.
+ */
+const EVENT_KINDS = {
+  approved: {
+    chip: "bg-(--success-9)",
+    icon: <CheckIcon className="size-2.5 text-white" strokeWidth={3.5} />,
+    text: "text-(--success-11)",
+  },
+  changes: {
+    chip: "bg-(--danger-9)",
+    icon: <XIcon className="size-2.5 text-white" strokeWidth={3.5} />,
+    text: "text-(--danger-11)",
+  },
+  comment: { chip: null, icon: null, text: "text-low" },
+};
+
+type ActivityEvent = {
+  name: string;
+  avatar: ThemeImageProps["src"];
+  kind: keyof typeof EVENT_KINDS;
+  action: string;
+  time: string;
+  comment?: React.ReactNode;
+  /** Number of the pin on the screenshot this comment is attached to. */
+  pin?: number;
+  reactions?: string;
+};
+
+/**
+ * An approval that a later verdict does not erase, then a handoff.
+ *
+ * Andrew signs off, Nina catches what he missed and requests changes, and
+ * Andrew hands the thread to his agent. Both decisions stay on the rail — that
+ * is the section's second point, and a last-click-wins model could not show it.
+ *
+ * The reply is written as the `@mention` the product actually accepts rather
+ * than as the `Handle with AI` menu item: the mention is what a reviewer types,
+ * so it reads without having to draw a menu that is closed in real life.
+ */
+const ACTIVITY: ActivityEvent[] = [
+  {
+    name: "Andrew",
+    avatar: andrewAvatar,
+    kind: "approved",
+    action: "approved",
+    time: "14m ago",
+  },
+  {
+    name: "Nina",
+    avatar: ninaAvatar,
+    kind: "changes",
+    action: "requested changes",
+    time: "4m ago",
+    comment: "This card shifted 4px right, the total is cut off.",
+    pin: 1,
+    reactions: "👍 2",
+  },
+  {
+    name: "Andrew",
+    avatar: andrewAvatar,
+    kind: "comment",
+    action: "replied",
+    time: "just now",
+    comment: (
+      <>
+        Good catch — <span className="text-(--violet-11)">@Claude</span> handle
+        this comment
+      </>
+    ),
+  },
+];
+
+function Activity() {
+  return (
+    <div className="flex flex-col">
+      <div className="border-b-[0.5px] px-3 py-2">
+        <SmallTitle className="text-low">Activity</SmallTitle>
+      </div>
+      <ol className="flex flex-col gap-4 p-3">
+        {ACTIVITY.map((event, index) => (
+          <ActivityRow
+            key={`${event.name}-${event.time}`}
+            event={event}
+            last={index === ACTIVITY.length - 1}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function ActivityRow(props: { event: ActivityEvent; last: boolean }) {
+  const { event, last } = props;
+  const kind = EVENT_KINDS[event.kind];
+  return (
+    <li className="relative flex gap-2.5">
+      {/* The rail runs from under this avatar into the gap below, so it stops
+          at the last event rather than trailing off the end of the list. */}
+      {last ? null : (
+        <span
+          className="absolute top-7 -bottom-4 left-3 w-px -translate-x-1/2 bg-(--neutral-6)"
+          aria-hidden
+        />
+      )}
+      {/* `self-start` keeps this box the size of the avatar; stretched to the
+          row it would drop the verdict chip to the bottom of the comment. */}
+      <span className="relative shrink-0 self-start">
+        <ThemeImage
+          src={event.avatar}
+          alt=""
+          className="size-6 rounded-full border-[0.5px] object-cover"
+        />
+        {kind.chip ? (
+          <span
+            className={clsx(
+              "absolute -right-1 -bottom-1 grid size-3.5 place-items-center rounded-full ring-2 ring-(--neutral-1)",
+              kind.chip,
+            )}
+          >
+            {kind.icon}
+          </span>
+        ) : null}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-1.5">
+          <span className="text-xs font-medium">{event.name}</span>
+          <span className={clsx("text-xs", kind.text)}>{event.action}</span>
+          <span className="text-low text-xxs">{event.time}</span>
+        </div>
+        {event.comment ? (
+          <p className="text-low mt-1 text-xs">
+            {event.pin ? <PinRef>{event.pin}</PinRef> : null}
+            {event.comment}
+          </p>
+        ) : null}
+        {event.reactions ? (
+          <Badge className="mt-1.5">{event.reactions}</Badge>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** Ties a comment back to its pin on the screenshot, by number. */
+function PinRef(props: { children: React.ReactNode }) {
+  return (
+    <span className="text-xxxs mr-1 inline-grid size-3.5 translate-y-px place-items-center rounded-full bg-(--pink-9) align-middle font-semibold text-white">
+      {props.children}
+    </span>
+  );
+}
+
+function Avatar(props: { src: ThemeImageProps["src"] }) {
+  return (
+    <ThemeImage
+      src={props.src}
+      alt=""
+      className="size-6 shrink-0 rounded-full border-[0.5px] object-cover ring-2 ring-(--neutral-1)"
+    />
+  );
+}

--- a/app/home/test-debugging/TestDebugging.tsx
+++ b/app/home/test-debugging/TestDebugging.tsx
@@ -1,7 +1,7 @@
 import { BugPlayIcon, ImageOffIcon, RotateCcwIcon } from "lucide-react";
 import Link from "next/link";
 
-import { leMondeQuote } from "@/app/assets/customers/library/le-monde";
+import { permitIoQuote } from "@/app/assets/customers/library/permit-io";
 import { Button } from "@/components/Button";
 import { FeatureSection } from "@/components/feature-section/FeatureSection";
 
@@ -48,10 +48,7 @@ export function TestDebugging() {
           <Link href="/test-debugging">Explore Test Debugging</Link>
         </Button>
       }
-      story={{
-        quote: leMondeQuote,
-        href: "/customers/lemonde",
-      }}
+      story={{ quote: permitIoQuote }}
     />
   );
 }

--- a/app/home/test-debugging/TestDebugging.tsx
+++ b/app/home/test-debugging/TestDebugging.tsx
@@ -1,7 +1,7 @@
 import { BugPlayIcon, ImageOffIcon, RotateCcwIcon } from "lucide-react";
 import Link from "next/link";
 
-import { permitIoQuote } from "@/app/assets/customers/library/permit-io";
+import { leMondeQuote } from "@/app/assets/customers/library/le-monde";
 import { Button } from "@/components/Button";
 import { FeatureSection } from "@/components/feature-section/FeatureSection";
 
@@ -48,7 +48,10 @@ export function TestDebugging() {
           <Link href="/test-debugging">Explore Test Debugging</Link>
         </Button>
       }
-      story={{ quote: permitIoQuote }}
+      story={{
+        quote: leMondeQuote,
+        href: "/customers/lemonde",
+      }}
     />
   );
 }

--- a/app/homepage.tsx
+++ b/app/homepage.tsx
@@ -7,6 +7,7 @@ import { defaultDescription, defaultTitle, getMetadata } from "@/lib/metadata";
 
 import { TrustedBy } from "./common/TrustedBy";
 import { AgentReady } from "./home/agent-ready/AgentReady";
+import { CollaborativeReviews } from "./home/collaborative-reviews/CollaborativeReviews";
 import { Cost } from "./home/cost/Cost";
 import { Customers } from "./home/customers/Customers";
 import { Deployments } from "./home/deployments/Deployments";
@@ -31,6 +32,7 @@ export default function Page() {
       <Hero />
       <TrustedBy />
       <VisualTesting />
+      <CollaborativeReviews />
       <AgentReady />
       <Deployments />
       <Integrations />

--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -379,6 +379,7 @@ function LinkCard(props: {
                 violet:
                   "group-hover:border-(--violet-10) group-hover:bg-(--violet-10)",
                 plum: "group-hover:border-(--plum-10) group-hover:bg-(--plum-10)",
+                pink: "group-hover:border-(--pink-10) group-hover:bg-(--pink-10)",
                 green:
                   "group-hover:border-(--green-10) group-hover:bg-(--green-10)",
               }[color]

--- a/components/FullPageGrid.tsx
+++ b/components/FullPageGrid.tsx
@@ -30,6 +30,7 @@ export function FullPageGrid(props: {
               teal: "bg-linear-to-t from-(--teal-3)/20",
               violet: "bg-linear-to-t from-(--violet-3)/20",
               plum: "bg-linear-to-t from-(--plum-3)/20",
+              pink: "bg-linear-to-t from-(--pink-3)/20",
               green: "bg-linear-to-t from-(--green-3)/20",
             }[props.tint],
           )}

--- a/components/feature-section/CustomerStory.tsx
+++ b/components/feature-section/CustomerStory.tsx
@@ -22,7 +22,12 @@ import { FROM_COLORS, type FeatureColor } from "./colors";
  */
 export function CustomerStory(props: {
   color: FeatureColor;
-  story?: { quote: CustomerQuote; href: string };
+  /**
+   * `href` points at the customer's case study. Leave it out for a customer who
+   * does not have one — the quote still stands, it just loses the button rather
+   * than pointing somewhere that is not a story.
+   */
+  story?: { quote: CustomerQuote; href?: string };
 }) {
   const { color, story } = props;
   return (
@@ -46,12 +51,14 @@ export function CustomerStory(props: {
                 “{story.quote.text}”
               </p>
             </blockquote>
-            <Button variant="outline" asChild>
-              <Link href={story.href}>
-                <BookTextIcon />
-                Read the story
-              </Link>
-            </Button>
+            {story.href ? (
+              <Button variant="outline" asChild>
+                <Link href={story.href}>
+                  <BookTextIcon />
+                  Read the story
+                </Link>
+              </Button>
+            ) : null}
           </div>
           <div className="flex flex-col items-center gap-6 text-center whitespace-nowrap md:items-end md:text-end">
             <ThemeImage

--- a/components/feature-section/CustomerStory.tsx
+++ b/components/feature-section/CustomerStory.tsx
@@ -1,0 +1,82 @@
+import clsx from "clsx";
+import { BookTextIcon } from "lucide-react";
+import Link from "next/link";
+
+import type { CustomerQuote } from "@/app/assets/customers/types";
+import { Button } from "@/components/Button";
+import { Pattern } from "@/components/Pattern";
+import { ThemeImage } from "@/components/ThemeImage";
+
+import { FROM_COLORS, type FeatureColor } from "./colors";
+
+/**
+ * The band a homepage section closes on, and the customer story inside it.
+ *
+ * The band is painted whether or not there is a story: it is the section's
+ * closing edge first, a frame for the quote second. That is why `story` is
+ * optional rather than the component being conditional at the call site.
+ *
+ * Shared so every section on the homepage closes the same way. The inner pages
+ * use `QuoteBlock` instead — centred, no story link — and the two must not be
+ * mixed on the same page or the quotes read as two different components.
+ */
+export function CustomerStory(props: {
+  color: FeatureColor;
+  story?: { quote: CustomerQuote; href: string };
+}) {
+  const { color, story } = props;
+  return (
+    <div className="relative">
+      <div
+        className={clsx("absolute inset-0 bg-linear-to-t", FROM_COLORS[color])}
+      />
+      <div className="absolute inset-x-4 inset-y-5 text-(--neutral-3)">
+        <Pattern />
+      </div>
+      {story ? (
+        <div className="relative flex flex-col items-center gap-10 px-10 py-12 text-center md:flex-row md:items-start md:gap-30 md:text-left">
+          <div className="flex flex-col items-center gap-6 md:items-start">
+            <blockquote>
+              <p
+                className={clsx(
+                  "font-accent bg-linear-to-b from-(--neutral-12) to-(--neutral-12)/80 bg-clip-text text-lg text-transparent md:text-2xl md:font-medium",
+                  "[&_strong]:font-semibold",
+                )}
+              >
+                “{story.quote.text}”
+              </p>
+            </blockquote>
+            <Button variant="outline" asChild>
+              <Link href={story.href}>
+                <BookTextIcon />
+                Read the story
+              </Link>
+            </Button>
+          </div>
+          <div className="flex flex-col items-center gap-6 text-center whitespace-nowrap md:items-end md:text-end">
+            <ThemeImage
+              src={story.quote.company.logo.adjusted}
+              alt={story.quote.company.name}
+              className="h-5 w-auto"
+            />
+            <div className="flex flex-col items-center gap-2.5 md:items-end">
+              <div>
+                <div className="text-sm font-medium">
+                  {story.quote.author.name}
+                </div>
+                <div className="text-low text-xs font-medium">
+                  {story.quote.author.title}
+                </div>
+              </div>
+              <ThemeImage
+                src={story.quote.author.avatar}
+                className="size-10 rounded-full border"
+                alt=""
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/feature-section/FeatureSection.tsx
+++ b/components/feature-section/FeatureSection.tsx
@@ -1,17 +1,13 @@
 import clsx from "clsx";
-import { BookTextIcon } from "lucide-react";
-import Link from "next/link";
 
 import type { CustomerQuote } from "@/app/assets/customers/types";
-import { Button } from "@/components/Button";
 import { Container } from "@/components/Container";
-import { Pattern } from "@/components/Pattern";
-import { ThemeImage } from "@/components/ThemeImage";
 
 import { SectionHeader, SectionHeaderTexts } from "../SectionHeader";
 import { SectionDescription, SectionTitle } from "../Typography";
+import { CustomerStory } from "./CustomerStory";
 import { type Feature, FeaturesCarousel } from "./FeaturesCarousel";
-import { FROM_COLORS, type FeatureColor, INDICATOR_BG_COLORS } from "./colors";
+import { type FeatureColor, INDICATOR_BG_COLORS } from "./colors";
 
 export function FeatureIndicator(props: {
   color: FeatureColor;
@@ -56,61 +52,7 @@ export function FeatureSection(props: {
           {cta}
         </SectionHeader>
         <FeaturesCarousel color={color} features={features} />
-        <div className="relative">
-          <div
-            className={clsx(
-              "absolute inset-0 bg-linear-to-t",
-              FROM_COLORS[color],
-            )}
-          />
-          <div className="absolute inset-x-4 inset-y-5 text-(--neutral-3)">
-            <Pattern />
-          </div>
-          {story ? (
-            <div className="relative flex flex-col items-center gap-10 px-10 py-12 text-center md:flex-row md:items-start md:gap-30 md:text-left">
-              <div className="flex flex-col items-center gap-6 md:items-start">
-                <blockquote>
-                  <p
-                    className={clsx(
-                      "font-accent bg-linear-to-b from-(--neutral-12) to-(--neutral-12)/80 bg-clip-text text-lg text-transparent md:text-2xl md:font-medium",
-                      "[&_strong]:font-semibold",
-                    )}
-                  >
-                    “{story.quote.text}”
-                  </p>
-                </blockquote>
-                <Button variant="outline" asChild>
-                  <Link href={story.href}>
-                    <BookTextIcon />
-                    Read the story
-                  </Link>
-                </Button>
-              </div>
-              <div className="flex flex-col items-center gap-6 text-center whitespace-nowrap md:items-end md:text-end">
-                <ThemeImage
-                  src={story.quote.company.logo.adjusted}
-                  alt={story.quote.company.name}
-                  className="h-5 w-auto"
-                />
-                <div className="flex flex-col items-center gap-2.5 md:items-end">
-                  <div>
-                    <div className="text-sm font-medium">
-                      {story.quote.author.name}
-                    </div>
-                    <div className="text-low text-xs font-medium">
-                      {story.quote.author.title}
-                    </div>
-                  </div>
-                  <ThemeImage
-                    src={story.quote.author.avatar}
-                    className="size-10 rounded-full border"
-                    alt=""
-                  />
-                </div>
-              </div>
-            </div>
-          ) : null}
-        </div>
+        <CustomerStory color={color} story={story} />
         <div className="h-12 border-t" />
       </Container>
     </div>

--- a/components/feature-section/FeatureSection.tsx
+++ b/components/feature-section/FeatureSection.tsx
@@ -31,7 +31,7 @@ export function FeatureSection(props: {
   features: Feature[];
   story?: {
     quote: CustomerQuote;
-    href: string;
+    href?: string;
   };
 }) {
   const { color, featureName, cta, title, description, features, story } =

--- a/components/feature-section/colors.tsx
+++ b/components/feature-section/colors.tsx
@@ -31,30 +31,6 @@ export const INDICATOR_BG_COLORS: Record<FeatureColor, string> = {
   green: "bg-(--green-10)",
 };
 
-/**
- * The hue a section's closing band fades up from.
- *
- * Step 2, shared rather than tuned per hue. Never step 1: that is Radix's
- * app-background step, white by construction in light — `blue-1` is #fbfdff
- * against a #fcfcfc page, ΔL* 0.2 — so the band only ever showed up in dark,
- * and even there only for blue, whose step 1 is the most saturated of the set.
- *
- * Measured against `--neutral-1`, the steps land at:
- *
- *     step 1   ΔL* 0.1-0.4 light   0.6-1.5 dark
- *     step 2   ΔL* 0.6-1.1 light   2.6-4.2 dark
- *     step 3   ΔL* 2.3-4.7 light   8.3-11.1 dark
- *
- * Step 2 is the quiet end of what registers. It is a deliberately faint band in
- * light; go to step 3 if it needs to carry from across the room.
- *
- * Lightness is not the whole story. Amber reads warmer than its ΔL* suggests,
- * because chroma carries it instead: `amber-2` is #fefbe9, 21 points between
- * channels, where `violet-2` spreads 7. The gap widens with the step — at 3 it
- * is 61 against 14 — so raising the step makes amber louder faster than the
- * rest. Evening that out needs a color-mix toward the neutral, not a
- * per-hue step.
- */
 export const FROM_COLORS: Record<FeatureColor, string> = {
   blue: "from-(--blue-2)",
   amber: "from-(--amber-2)",

--- a/components/feature-section/colors.tsx
+++ b/components/feature-section/colors.tsx
@@ -31,12 +31,30 @@ export const INDICATOR_BG_COLORS: Record<FeatureColor, string> = {
   green: "bg-(--green-10)",
 };
 
+/**
+ * The hue a section's closing band fades up from.
+ *
+ * Step 3, shared rather than tuned per hue. Never step 1: that is Radix's
+ * app-background step, white by construction in light — `blue-1` is #fbfdff
+ * against a #fcfcfc page, ΔL* 0.2 — so the band only ever showed up in dark,
+ * and even there only for blue, whose step 1 is the most saturated of the set.
+ *
+ * Measured against `--neutral-1`, step 3 puts all seven hues at ΔL* 2.3-4.7 in
+ * light and 8.3-11.1 in dark. It is the first step where every hue reads in
+ * both themes; step 1 sits at 0.1-0.4 and 0.6-1.5, i.e. nothing.
+ *
+ * Lightness is not the whole story. Amber has the lowest ΔL* of the set here
+ * yet reads loudest, because chroma carries it instead: `amber-2` is #fff7c2,
+ * 61 points between channels, where `violet-2` spreads 14. Evening that out
+ * needs a colour-mix toward the neutral, not a different step — moving amber
+ * down would only make the band it already has the faintest of disappear.
+ */
 export const FROM_COLORS: Record<FeatureColor, string> = {
-  blue: "from-(--blue-1)",
-  amber: "from-(--amber-1)",
-  teal: "from-(--teal-1)",
-  violet: "from-(--violet-1)",
-  plum: "from-(--plum-1)",
-  pink: "from-(--pink-1)",
-  green: "from-(--green-1)",
+  blue: "from-(--blue-2)",
+  amber: "from-(--amber-2)",
+  teal: "from-(--teal-2)",
+  violet: "from-(--violet-2)",
+  plum: "from-(--plum-2)",
+  pink: "from-(--pink-2)",
+  green: "from-(--green-2)",
 };

--- a/components/feature-section/colors.tsx
+++ b/components/feature-section/colors.tsx
@@ -1,10 +1,5 @@
 export type FeatureColor =
-  | "blue"
-  | "amber"
-  | "teal"
-  | "violet"
-  | "plum"
-  | "green";
+  "blue" | "amber" | "teal" | "violet" | "plum" | "pink" | "green";
 
 export const BORDER_BG_COLORS: Record<FeatureColor, string> = {
   blue: "bg-(--blue-9)",
@@ -12,6 +7,7 @@ export const BORDER_BG_COLORS: Record<FeatureColor, string> = {
   teal: "bg-(--teal-9)",
   violet: "bg-(--violet-9)",
   plum: "bg-(--plum-9)",
+  pink: "bg-(--pink-9)",
   green: "bg-(--green-9)",
 };
 
@@ -21,6 +17,7 @@ export const TEXT_COLORS: Record<FeatureColor, string> = {
   teal: "text-(--teal-11)",
   violet: "text-(--violet-11)",
   plum: "text-(--plum-11)",
+  pink: "text-(--pink-11)",
   green: "text-(--green-11)",
 };
 
@@ -30,6 +27,7 @@ export const INDICATOR_BG_COLORS: Record<FeatureColor, string> = {
   teal: "bg-(--teal-10)",
   violet: "bg-(--violet-10)",
   plum: "bg-(--plum-10)",
+  pink: "bg-(--pink-10)",
   green: "bg-(--green-10)",
 };
 
@@ -39,5 +37,6 @@ export const FROM_COLORS: Record<FeatureColor, string> = {
   teal: "from-(--teal-1)",
   violet: "from-(--violet-1)",
   plum: "from-(--plum-1)",
+  pink: "from-(--pink-1)",
   green: "from-(--green-1)",
 };

--- a/components/feature-section/colors.tsx
+++ b/components/feature-section/colors.tsx
@@ -34,20 +34,26 @@ export const INDICATOR_BG_COLORS: Record<FeatureColor, string> = {
 /**
  * The hue a section's closing band fades up from.
  *
- * Step 3, shared rather than tuned per hue. Never step 1: that is Radix's
+ * Step 2, shared rather than tuned per hue. Never step 1: that is Radix's
  * app-background step, white by construction in light — `blue-1` is #fbfdff
  * against a #fcfcfc page, ΔL* 0.2 — so the band only ever showed up in dark,
  * and even there only for blue, whose step 1 is the most saturated of the set.
  *
- * Measured against `--neutral-1`, step 3 puts all seven hues at ΔL* 2.3-4.7 in
- * light and 8.3-11.1 in dark. It is the first step where every hue reads in
- * both themes; step 1 sits at 0.1-0.4 and 0.6-1.5, i.e. nothing.
+ * Measured against `--neutral-1`, the steps land at:
  *
- * Lightness is not the whole story. Amber has the lowest ΔL* of the set here
- * yet reads loudest, because chroma carries it instead: `amber-2` is #fff7c2,
- * 61 points between channels, where `violet-2` spreads 14. Evening that out
- * needs a colour-mix toward the neutral, not a different step — moving amber
- * down would only make the band it already has the faintest of disappear.
+ *     step 1   ΔL* 0.1-0.4 light   0.6-1.5 dark
+ *     step 2   ΔL* 0.6-1.1 light   2.6-4.2 dark
+ *     step 3   ΔL* 2.3-4.7 light   8.3-11.1 dark
+ *
+ * Step 2 is the quiet end of what registers. It is a deliberately faint band in
+ * light; go to step 3 if it needs to carry from across the room.
+ *
+ * Lightness is not the whole story. Amber reads warmer than its ΔL* suggests,
+ * because chroma carries it instead: `amber-2` is #fefbe9, 21 points between
+ * channels, where `violet-2` spreads 7. The gap widens with the step — at 3 it
+ * is 61 against 14 — so raising the step makes amber louder faster than the
+ * rest. Evening that out needs a color-mix toward the neutral, not a
+ * per-hue step.
  */
 export const FROM_COLORS: Record<FeatureColor, string> = {
   blue: "from-(--blue-2)",


### PR DESCRIPTION
Adds a Collaborative Reviews section to the homepage, between Change Detection and the agents section.

<img width="600" alt="CleanShot 2026-08-06 at 10 13 30@2x" src="https://github.com/user-attachments/assets/46abe299-39da-42f2-bcdc-d27e4787a82d" />
