### PR TITLE
Rebuild the agents section around one agent session

### DIFF
--- a/app/home/agent-ready/AgentReady.tsx
+++ b/app/home/agent-ready/AgentReady.tsx
@@ -1,9 +1,3 @@
-import {
-  ClipboardCheckIcon,
-  PlugIcon,
-  RefreshCwIcon,
-  ScanEyeIcon,
-} from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/Button";
@@ -12,30 +6,7 @@ import { SectionHeader, SectionHeaderTexts } from "@/components/SectionHeader";
 import { SectionDescription, SectionTitle } from "@/components/Typography";
 import { FeatureIndicator } from "@/components/feature-section/FeatureSection";
 
-import { AgentTerminal } from "./AgentTerminal";
-
-const POINTS = [
-  {
-    icon: ScanEyeIcon,
-    title: "Agents see the diff",
-    text: "Machine-readable snapshots let an agent read exactly what its change did to the UI, the Markdown, or the API output.",
-  },
-  {
-    icon: RefreshCwIcon,
-    title: "Agents iterate and self-correct",
-    text: "When Argos surfaces an unintended change, the agent has the context to fix its own mistake before you ever look.",
-  },
-  {
-    icon: ClipboardCheckIcon,
-    title: "Agents review from the CLI",
-    text: "Inspect a build, list what needs review, and submit a decision, or hit Copy prompt to hand an agent the full context.",
-  },
-  {
-    icon: PlugIcon,
-    title: "Agents connect over MCP",
-    text: "Connect Claude, Cursor, or any MCP client to the Argos MCP server with OAuth — every review action, natively in your agent.",
-  },
-];
+import { AgentShowcase } from "./AgentShowcase";
 
 export function AgentReady() {
   return (
@@ -43,39 +14,29 @@ export function AgentReady() {
       <Container noGutter className="border-x">
         <SectionHeader className="container-gutter">
           <SectionHeaderTexts>
-            <FeatureIndicator color="violet">
-              Built for the AI age
-            </FeatureIndicator>
-            <SectionTitle>100% agent-ready</SectionTitle>
+            {/* A product area, like "Change Detection" and "Collaborative
+                Reviews" above — and the destination of the CTA below. "Built
+                for the AI age" named an era instead, and broke the run. */}
+            <FeatureIndicator color="violet">AI Agents</FeatureIndicator>
+            {/* The claim the section above cannot make. Collaborative Reviews
+                already told the reader that agents pick up a thread, so
+                "100% agent-ready" arrived as old news, and as a spec where
+                every neighbouring title is a verb-led benefit. */}
+            <SectionTitle>Your agents check their own work</SectionTitle>
+            {/* One line, to sit at the same weight as the one-line description
+                above it, and ordered so it announces the three rows. The long
+                version led on CLI and MCP — the transport, which the terminal
+                to the right already shows. */}
             <SectionDescription className="max-w-2xl">
-              Your agents write the code. Argos gives them (and you) the ground
-              truth of what actually changed, from the MCP server, CLI, and REST
-              API they already use.
+              They read what their change did, fix what they broke, and only
+              bring you what’s left.
             </SectionDescription>
           </SectionHeaderTexts>
           <Button variant="outline" asChild>
             <Link href="/ai-agents">Explore Argos for AI Agents</Link>
           </Button>
         </SectionHeader>
-        <div className="grid border-t md:grid-cols-2">
-          <ul className="flex flex-col divide-y border-b md:border-r md:border-b-0">
-            {POINTS.map((point) => (
-              <li key={point.title} className="flex gap-4 p-6 md:p-8">
-                <point.icon
-                  className="mt-0.5 size-5 shrink-0 text-(--violet-11)"
-                  strokeWidth={1.5}
-                />
-                <div>
-                  <h3 className="font-accent font-medium">{point.title}</h3>
-                  <p className="text-low text-sm">{point.text}</p>
-                </div>
-              </li>
-            ))}
-          </ul>
-          <div className="relative flex cursor-default items-center justify-center p-6 md:p-10">
-            <AgentTerminal />
-          </div>
-        </div>
+        <AgentShowcase />
       </Container>
     </section>
   );

--- a/app/home/agent-ready/AgentShowcase.tsx
+++ b/app/home/agent-ready/AgentShowcase.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import clsx from "clsx";
+import { BracesIcon, InboxIcon, RefreshCwIcon } from "lucide-react";
+import { useId, useRef, useState } from "react";
+
+import {
+  AgentTerminal,
+  Ref,
+  type TerminalLine,
+  Verdict,
+} from "./AgentTerminal";
+
+type Step = {
+  key: string;
+  icon: typeof BracesIcon;
+  title: string;
+  text: string;
+  lines: TerminalLine[];
+};
+
+/**
+ * One instruction, three stages of the agent working on its own.
+ *
+ * The reader asks for a feature and never mentions Argos, a build, or a
+ * review. Everything the agent does with Argos after that — pulling the diffs,
+ * catching its own regression, deciding the PR is ready — is its own
+ * initiative. That is the section title argued by the content rather than
+ * asserted by it, and it is why the prompt is identical on all three rows:
+ * moving between them, the ask holds still and only the work advances.
+ *
+ * There is deliberately no command output anywhere. What convinces here is the
+ * agent saying what it found and what it is about to do; a count of diffs and a
+ * score only ever proved that a command exists. Every `tool` line names a call,
+ * never its result, and no two rows repeat the same one — a step that re-ran
+ * the previous step's command read as an agent that had forgotten it. The
+ * middle row has none at all, which is not an omission: see the note on it.
+ *
+ * MCP stays out of the illustration. It is real, and the first row's body says
+ * so, but staging a flow around it would put the weight on the transport the
+ * fewest readers use, instead of the one they already reach for.
+ *
+ * Two snapshots, not three: one the reader asked for and one the agent broke.
+ * That is the smallest set the story needs — the intentional change is what
+ * survives to the review queue, the regression is what the agent clears — and
+ * every extra one had to be tracked across all three rows for no added meaning.
+ */
+const PROMPT = "add a promo code field to the checkout";
+
+const STEPS: Step[] = [
+  {
+    key: "read",
+    icon: BracesIcon,
+    title: "Agents see what you see",
+    text: "Every diff in the Argos UI is also structured data, from the CLI and over MCP. No dashboard, no screenshots pasted into a prompt.",
+    lines: [
+      {
+        kind: "assistant",
+        text: (
+          <>
+            PR <Ref>#359</Ref> pushed. Waiting for CI…
+          </>
+        ),
+      },
+      // The build finishing is what the agent was waiting for; pulling the
+      // diffs is the next thing it does, unprompted. Without this line the row
+      // shows Argos notifying rather than the agent reading, which is the one
+      // claim its title makes that Change Detection above does not.
+      { kind: "tool", text: "argos build snapshots 517" },
+      {
+        kind: "assistant",
+        // "I added" against a bare "the price tag" is what sorts them: one is
+        // the feature, the other is not yet named as damage. The next row is
+        // where it becomes a regression.
+        text: "Argos flagged two changes: the promo field I added, and the price tag on mobile.",
+      },
+    ],
+  },
+  {
+    key: "fix",
+    icon: RefreshCwIcon,
+    title: "Agents fix what they broke",
+    text: "When Argos surfaces a change nobody asked for, the agent has what it needs to correct it and push again.",
+    // The only row with no `tool` line, and deliberately so: this is where the
+    // agent works on the code, not on Argos. The previous row already pulled
+    // the diffs, so any Argos call here would either repeat it — reading as an
+    // agent that had forgotten — or invent a second one to fill a slot the step
+    // does not need.
+    lines: [
+      {
+        kind: "assistant",
+        // The attribution is the row. Without "the flex change I made", the
+        // agent merely finds a regression — which is what Change Detection does
+        // two sections above — instead of owning one, which is what the title
+        // claims.
+        text: (
+          <>
+            <Verdict>Regression found on the price tag</Verdict>: it overflows
+            its card on mobile, from the flex change I made for the promo field.
+            Fixing…
+          </>
+        ),
+      },
+      {
+        kind: "assistant",
+        text: (
+          <>
+            Commit <Ref>ff26ba0</Ref> pushed. Waiting for CI…
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    key: "queue",
+    icon: InboxIcon,
+    title: "You only review what’s left",
+    text: "The regressions an agent catches never reach you. What lands in your queue is the change that actually needs a human.",
+    lines: [
+      { kind: "tool", text: "argos build snapshots 518" },
+      {
+        kind: "assistant",
+        text: "The regression is gone — on the latest build, the price tag is back on baseline.",
+      },
+      {
+        kind: "assistant",
+        // Naming what is left is the whole row. "The PR is ready for your
+        // review" is a GitHub sentence: it says the branch is done, not that
+        // exactly one snapshot reached you, which is the claim the title makes.
+        text: (
+          <>
+            PR <Ref>#359</Ref> is ready. The promo field is the only change
+            detected. It’s waiting for your approval in Argos.
+          </>
+        ),
+      },
+    ],
+  },
+];
+
+/**
+ * The points drive the terminal instead of sitting beside it.
+ *
+ * As a static list opposite a fixed panel, nothing said which row the panel was
+ * illustrating — the reader had to assume it stood for all of them, which made
+ * it decoration. Selecting a row and watching the terminal answer is what turns
+ * the two columns into one demonstration.
+ *
+ * The three panels are one story read top to bottom: build #517 has two
+ * changes, the agent clears the one it caused, and #518 leaves you the one you
+ * asked for. Three unrelated vignettes would have demonstrated three commands;
+ * this demonstrates the loop.
+ */
+export function AgentShowcase() {
+  const [index, setIndex] = useState(0);
+  const baseId = useId();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const current = STEPS[index];
+  if (!current) {
+    throw new Error(`Invalid index ${index}`);
+  }
+
+  const move = (to: number) => {
+    const next = (to + STEPS.length) % STEPS.length;
+    setIndex(next);
+    tabRefs.current[next]?.focus();
+  };
+
+  return (
+    <div className="grid border-t md:grid-cols-2">
+      <div
+        role="tablist"
+        aria-orientation="vertical"
+        aria-label="Agent capabilities"
+        className="flex flex-col divide-y border-b md:border-r md:border-b-0"
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+            event.preventDefault();
+            move(index + 1);
+          } else if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+            event.preventDefault();
+            move(index - 1);
+          }
+        }}
+      >
+        {STEPS.map((step, stepIndex) => {
+          const isCurrent = stepIndex === index;
+          return (
+            <button
+              key={step.key}
+              type="button"
+              role="tab"
+              id={`${baseId}-tab-${step.key}`}
+              aria-selected={isCurrent}
+              aria-controls={`${baseId}-panel`}
+              tabIndex={isCurrent ? 0 : -1}
+              ref={(node) => {
+                tabRefs.current[stepIndex] = node;
+              }}
+              onClick={() => setIndex(stepIndex)}
+              className={clsx(
+                "relative flex cursor-pointer gap-4 p-6 text-left transition-colors duration-200 md:p-8",
+                isCurrent ? "bg-(--violet-3)" : "hover:bg-(--violet-2)",
+              )}
+            >
+              {/* The row the reader is on, drawn over the divider. */}
+              <span
+                aria-hidden
+                className={clsx(
+                  "absolute inset-y-0 left-0 w-0.5 bg-(--violet-9) transition-opacity duration-200",
+                  isCurrent ? "opacity-100" : "opacity-0",
+                )}
+              />
+              <step.icon
+                className={clsx(
+                  "mt-0.5 size-5 shrink-0 transition-colors duration-200",
+                  isCurrent ? "text-(--violet-11)" : "text-low",
+                )}
+                strokeWidth={1.5}
+              />
+              <div>
+                <h3 className="font-accent font-medium">{step.title}</h3>
+                <p className="text-low text-sm">{step.text}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      <div
+        role="tabpanel"
+        id={`${baseId}-panel`}
+        aria-labelledby={`${baseId}-tab-${current.key}`}
+        className="relative flex cursor-default items-center justify-center p-6 md:p-10"
+      >
+        <AgentTerminal
+          prompt={PROMPT}
+          conversations={STEPS}
+          activeKey={current.key}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/home/agent-ready/AgentTerminal.tsx
+++ b/app/home/agent-ready/AgentTerminal.tsx
@@ -1,93 +1,138 @@
-"use client";
-
 import clsx from "clsx";
-import { CheckIcon, ClipboardIcon, TerminalIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 
-import { ArgosEmblem } from "@/components/ArgosEmblem";
-import { Badge } from "@/components/Badge";
-import { DotIndicator } from "@/components/DotIndicator";
+import { ClaudeMark } from "./ClaudeMark";
 
-const EASTER_EGG_PROMPT =
-  "Help me set up Argos in my project so my agents stop shipping visual bugs 👀";
+/**
+ * The verdict in a turn, when there is one. Weight rather than color: violet
+ * already means three things in this card — your input, the selected row, the
+ * caret — and a fourth would stop it meaning any of them.
+ */
+export function Verdict(props: { children: ReactNode }) {
+  return <strong className="font-semibold">{props.children}</strong>;
+}
 
-type TerminalLine =
-  | { kind: "prompt"; text: string }
-  | { kind: "output"; text: string }
-  | { kind: "status"; text: string };
+/**
+ * An identifier the agent is referring to.
+ *
+ * Monospace was the first instinct — it is the convention for a name you could
+ * paste somewhere — but a mono space is wider than the surrounding prose one,
+ * so "PR #359" came out looking like a typo. The accent carries the same job
+ * with no gap, and inside prose it reads as a reference rather than as the
+ * chrome meanings violet has elsewhere in this card.
+ */
+export function Ref(props: { children: ReactNode }) {
+  return <span className="text-(--violet-11)">{props.children}</span>;
+}
 
-const LINES: TerminalLine[] = [
-  { kind: "prompt", text: "argos build snapshots 1234 --needs-review" },
-  { kind: "output", text: "→ 3 snapshots changed · 1 flaky · machine-readable" },
-  { kind: "prompt", text: "argos review create 1234 --event approve" },
-  { kind: "status", text: "Review submitted, safe to merge" },
-];
+/**
+ * A conversation, not a command log.
+ *
+ * The panel used to print CLI output — a count of diffs, a build conclusion,
+ * a score. None of that is what the reader needs to believe the section: the
+ * claim is that an agent reads a build and acts on it, and the thing that
+ * demonstrates it is the agent saying what it found and what it is going to do.
+ * Raw output only proved that a command exists.
+ *
+ * The shape follows a real Claude session in a terminal: what you typed sits in
+ * a filled band, the reply is plain prose under it with nothing marking it, and
+ * the caret waiting for your next message closes the window. Nothing here
+ * labels the speakers — the band already says which turn is yours.
+ *
+ * Only the typed things are monospaced: your line and the tool call. The
+ * agent's prose is set in the page's own face, because that is how it reads in
+ * the real client — as writing, not as output.
+ *
+ * `tool` names the call the agent made, never its result, so the reader can see
+ * the Argos CLI is doing real work without the panel becoming a transcript.
+ */
+export type TerminalLine =
+  | { kind: "tool"; text: string }
+  // A node rather than a string, so a turn can carry a `Verdict` or a `Ref`
+  // without the panel growing a markup dialect of its own.
+  | { kind: "assistant"; text: ReactNode };
 
-export function AgentTerminal() {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) {
-      return;
-    }
-    const id = window.setTimeout(() => setCopied(false), 2000);
-    return () => window.clearTimeout(id);
-  }, [copied]);
-
-  const handleCopy = () => {
-    navigator.clipboard?.writeText(EASTER_EGG_PROMPT).then(
-      () => setCopied(true),
-      () => {},
-    );
-  };
+export function AgentTerminal(props: {
+  /**
+   * The one thing you asked for. It is the same across every step and sits
+   * outside the swapped block on purpose: moving between rows must not
+   * re-render it, so the reader sees a single instruction holding still while
+   * the agent's work advances underneath.
+   */
+  prompt: string;
+  /**
+   * Every conversation, not just the visible one.
+   *
+   * They are stacked in a single grid cell with the inactive ones hidden, so
+   * the card is always as tall as its longest step at whatever width it is
+   * being read. A hand-tuned `min-height` did the same job only at the width it
+   * was measured at: below ~900px the column narrows, the text wraps further,
+   * and the card went back to growing and shrinking between tabs.
+   */
+  conversations: { key: string; lines: TerminalLine[] }[];
+  activeKey: string;
+}) {
+  const { prompt, conversations, activeKey } = props;
 
   return (
-    <div className="bg-app animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both w-full max-w-md overflow-hidden rounded-xl border-[0.5px] shadow-md/7">
-      <div className="flex items-center justify-between border-b-[0.5px] px-3 py-2">
-        <div className="text-low flex items-center gap-2 text-xs font-medium">
-          <TerminalIcon className="size-3.5" />
-          Terminal
-        </div>
-        <Badge className="text-low text-xxs gap-1">
-          <ArgosEmblem className="size-3 text-(--violet-11)" />
-          @argos-ci/cli
-        </Badge>
+    <div className="bg-app animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both w-full max-w-md overflow-hidden rounded-xl border-[0.5px] shadow-md/7 dark:border-(--neutral-7)">
+      {/* The agent is named once, here, instead of on every turn it takes. */}
+      <div className="flex items-center gap-2 border-b-[0.5px] px-3 py-2">
+        <ClaudeMark className="size-3.5 shrink-0" />
+        <span className="text-low text-xs font-medium">Claude Code</span>
       </div>
 
-      <div className="text-xxs space-y-1.5 p-4 font-mono leading-relaxed">
-        {LINES.map((line, index) => (
-          <Line key={index} line={line} />
-        ))}
-        <div className="flex items-center gap-2">
-          <span className="text-(--violet-11)">$</span>
-          <span className="inline-block h-3 w-1.5 animate-pulse bg-(--violet-9)" />
-        </div>
+      {/* The filled band is what marks the turn as yours — the device the real
+          session uses, and the reason no name is needed. Monospaced, since this
+          is the one line that was actually typed. */}
+      <div className="text-xxs mt-2 flex gap-2 bg-(--neutral-3) px-4 py-1.5 font-mono">
+        <span aria-hidden className="shrink-0 text-(--violet-11)">
+          ›
+        </span>
+        <p className="text-default">{prompt}</p>
       </div>
 
-      <div className="flex items-center justify-between border-t-[0.5px] px-3 py-2">
-        <span className="text-low text-xxs">Start a review from any build</span>
-        <button
-          type="button"
-          onClick={handleCopy}
-          className={clsx(
-            "text-xxs inline-flex cursor-pointer items-center gap-1 rounded-lg border-[0.5px] px-2 py-1 font-medium transition",
-            copied
-              ? "border-(--success-7) text-(--success-11)"
-              : "border-(--violet-7) text-(--violet-11) hover:bg-(--violet-3)",
-          )}
-        >
-          {copied ? (
-            <>
-              <CheckIcon className="size-3" />
-              Copied!
-            </>
-          ) : (
-            <>
-              <ClipboardIcon className="size-3" />
-              Copy prompt
-            </>
-          )}
-        </button>
+      {/* Every step occupies the same grid cell. The hidden ones still take
+          their space, so the cell is the height of the longest at any width,
+          and `visibility: hidden` keeps them out of the accessibility tree.
+          No horizontal padding: each line pads itself, so a full-bleed row
+          stays possible. */}
+      <div className="grid">
+        {conversations.map((conversation) => {
+          const isActive = conversation.key === activeKey;
+          return (
+            <div
+              key={conversation.key}
+              aria-hidden={!isActive}
+              // Applying the fade class as a step becomes active is what
+              // replays it — the node is only ever given the class on the
+              // transition into view.
+              className={clsx(
+                "col-start-1 row-start-1 space-y-2.5 pt-3 pb-6",
+                isActive
+                  ? "animate-fade-in animate-duration-300 fill-mode-both"
+                  : "invisible",
+              )}
+            >
+              {conversation.lines.map((line, index) => (
+                <Line key={index} line={line} />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* The caret waiting for your next message. It is the only live element
+          left: in a finished exchange the cursor sits at the input, not in the
+          middle of something the agent already said. */}
+      <div className="flex items-center gap-2 border-t-[0.5px] px-4 py-2.5">
+        <span aria-hidden className="text-xxs font-mono text-(--violet-11)">
+          ›
+        </span>
+        <span
+          aria-hidden
+          className="inline-block h-3 w-1.5 animate-pulse bg-(--violet-9)"
+        />
       </div>
     </div>
   );
@@ -95,26 +140,39 @@ export function AgentTerminal() {
 
 function Line(props: { line: TerminalLine }) {
   const { line } = props;
+
+  if (line.kind === "tool") {
+    // Dimmed, and hung off the same edge as the prose: the agent reaching for
+    // Argos, subordinate to the turn above it rather than a command the reader
+    // is invited to run. The empty first cell matches the bullet's box, so the
+    // indent stays right without a magic number.
+    return (
+      <div className="flex gap-2 px-4">
+        <span aria-hidden className="size-1.5 shrink-0" />
+        <span className="text-low text-xxs flex items-center gap-1.5 font-mono">
+          {/* Drawn rather than typed. `⎿` is a box-drawing character, so its
+              shape depends on whichever font resolves it — the same reason the
+              answer bullet is a span and not a glyph. */}
+          <span
+            aria-hidden
+            className="mb-0.5 size-1.5 shrink-0 rounded-bl-[1px] border-b border-l border-(--neutral-8)"
+          />
+          <span>{line.text}</span>
+        </span>
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={clsx(
-        line.kind === "output" && "text-low pl-4",
-        line.kind !== "output" && "flex items-center gap-2",
-      )}
-    >
-      {line.kind === "prompt" ? (
-        <>
-          <span className="text-(--violet-11)">$</span>
-          <span className="text-default">{line.text}</span>
-        </>
-      ) : line.kind === "status" ? (
-        <>
-          <DotIndicator variant="success" />
-          <span className="text-(--success-11)">{line.text}</span>
-        </>
-      ) : (
-        <span>{line.text}</span>
-      )}
+    <div className="flex gap-2 px-4">
+      {/* The disc the real client puts in front of every answer. Drawn rather
+          than typed: a glyph would take its size from whichever font resolved,
+          and this one has to line up with prose set in the page's face. */}
+      <span
+        aria-hidden
+        className="mt-1.5 size-1.5 shrink-0 rounded-full bg-(--violet-9)"
+      />
+      <p className="text-default text-xs leading-relaxed">{line.text}</p>
     </div>
   );
 }

--- a/app/home/agent-ready/ClaudeMark.tsx
+++ b/app/home/agent-ready/ClaudeMark.tsx
@@ -1,0 +1,29 @@
+import { SVGProps } from "react";
+
+/**
+ * `#D97757` is Anthropic's terracotta, baked in rather than read from a token:
+ * the site's `--orange-9` is `#f76b15`, a vivid orange that is nobody's brand
+ * color, and a mark in the wrong color is worse than no mark.
+ *
+ * No `<title>`: the mark is always rendered beside a "Claude Code" label, so
+ * naming it here made a screen reader announce the product twice. An icon that
+ * repeats its own caption is decoration, and decoration is hidden.
+ */
+export function ClaudeMark(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden
+      className={props.className}
+      {...props}
+    >
+      <path
+        fill="#D97757"
+        fillRule="evenodd"
+        d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0v-3.1h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Rework agents chapter on homepage
<img width="1774" height="1220" alt="CleanShot 2026-08-06 at 15 52 57@2x" src="https://github.com/user-attachments/assets/20e53e86-d495-4a63-ad97-65c928b9eef4" />

<img width="1796" height="1226" alt="CleanShot 2026-08-06 at 15 53 01@2x" src="https://github.com/user-attachments/assets/27def277-6d53-496f-b02f-65d380e87bf5" />

<img width="1774" height="1216" alt="CleanShot 2026-08-06 at 15 53 04@2x" src="https://github.com/user-attachments/assets/450dfd76-dc03-43f7-b987-c28fe5f6e3ea" />

<img width="1782" height="1222" alt="CleanShot 2026-08-06 at 15 53 15@2x" src="https://github.com/user-attachments/assets/dd30c9c1-4aa5-497e-8f2c-8d29db51343d" />
