### PR TITLE
Agent readiness: Link headers, auth.md, llms.txt, markdown negotiation, WebMCP

### DIFF
--- a/app/auth.md/route.ts
+++ b/app/auth.md/route.ts
@@ -1,0 +1,95 @@
+import {
+  API_DOCS_URL,
+  API_URL,
+  MCP_DOCS_URL,
+  MCP_URL,
+  OAUTH_ISSUER,
+  OAUTH_SCOPES,
+  markdownHeaders,
+} from "@/lib/agents";
+
+export const dynamic = "force-static";
+
+/**
+ * auth.md (https://workos.com/auth-md): how agents obtain credentials for
+ * Argos. Everything here mirrors the OAuth authorization server metadata at
+ * https://app.argos-ci.com/.well-known/oauth-authorization-server — the
+ * endpoints are real, keep them in sync with the argos backend.
+ */
+const authMd = `# Argos auth.md
+
+This document describes how AI agents and automated clients authenticate to
+[Argos](https://argos-ci.com), the visual testing platform.
+
+## Who this is for
+
+Agents that want to call the [Argos REST API](${API_DOCS_URL})
+(\`${API_URL}\`) or connect to the
+[Argos MCP server](${MCP_DOCS_URL}) (\`${MCP_URL}\`).
+
+Both resources accept the same bearer tokens, issued by the Argos OAuth 2.1
+authorization server at \`${OAUTH_ISSUER}\`. Argos accounts belong to humans:
+an agent always acts on behalf of a user who signs in and grants it access.
+
+## Discovery
+
+- Authorization server metadata (RFC 8414): \`${OAUTH_ISSUER}/.well-known/oauth-authorization-server\`
+- Protected resource metadata (RFC 9728): \`https://api.argos-ci.com/.well-known/oauth-protected-resource\` and \`${MCP_URL}/.well-known/oauth-protected-resource\`
+- API catalog (RFC 9727): \`https://argos-ci.com/.well-known/api-catalog\`
+- MCP server card: \`https://argos-ci.com/.well-known/mcp/server-card.json\`
+
+## Method 1: OAuth 2.1 (recommended)
+
+The authorization server supports **dynamic client registration** (RFC 7591) —
+agents can register themselves without a human pre-creating a client:
+
+1. \`POST ${OAUTH_ISSUER}/oauth/register\` with your client metadata to obtain a \`client_id\`.
+2. Run the authorization code flow with PKCE (\`S256\`) at \`${OAUTH_ISSUER}/oauth/authorize\`. A browser opens and the user signs in, picks the organizations to share, and grants scopes.
+3. Exchange the code at \`${OAUTH_ISSUER}/oauth/token\`. Refresh tokens are supported.
+
+MCP clients (Claude Code, Claude.ai, Cursor, VS Code, Codex, Windsurf…) do all
+of this automatically per the MCP authorization spec — just add
+\`${MCP_URL}\` as an HTTP MCP server:
+
+\`\`\`bash
+claude mcp add --transport http argos ${MCP_URL}
+\`\`\`
+
+## Method 2: Personal access token
+
+For clients where OAuth is impractical, a user can create a personal access
+token in their Argos settings ([app.argos-ci.com](https://app.argos-ci.com))
+and hand it to the agent. See the
+[API reference](${API_DOCS_URL}) for details.
+
+## Using tokens
+
+Send the token as a bearer credential:
+
+\`\`\`http
+Authorization: Bearer <token>
+\`\`\`
+
+## Scopes
+
+${OAUTH_SCOPES.map((scope) => `- \`${scope}\``).join("\n")}
+
+Broadly: \`projects:*\` covers project configuration, \`builds:write\` and
+\`reviews:write\` cover build review, \`comments:*\` covers build comments, and
+\`account:admin\` covers team administration.
+
+## Revocation
+
+- Tokens can be revoked at \`${OAUTH_ISSUER}/oauth/revoke\` (RFC 7009).
+- Users can revoke any agent's access at any time from **Authorized
+  applications** in their Argos settings.
+
+## Rate limits and support
+
+The API is rate limited; see [rate limits](${API_DOCS_URL}/rate-limits).
+Questions: contact@argos-ci.com or https://argos-ci.com/discord.
+`;
+
+export function GET() {
+  return new Response(authMd, { headers: markdownHeaders(authMd) });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Organization } from "schema-dts";
 
 import { JsonLd } from "@/components/JsonLd";
 import { TooltipProvider } from "@/components/Tooltip";
+import { WebMcp } from "@/components/WebMcp";
 import { defaultDescription, defaultTitle } from "@/lib/metadata";
 import "@/styles/globals.css";
 import "@/styles/highlight-js-github-dark.min.css";
@@ -106,6 +107,7 @@ export default function RootLayout({
       </head>
       <body>
         <JsonLd json={jsonLdOrganization} />
+        <WebMcp />
         <ClientProviders>
           <TooltipProvider>
             <div id="content">

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,55 @@
+import { markdownHeaders } from "@/lib/agents";
+
+export const dynamic = "force-static";
+
+/**
+ * llms.txt (https://llmstxt.org/): a curated markdown map of Argos for AI
+ * agents. The documentation has its own, exhaustive /docs/llms.txt (served by
+ * GitBook); this one covers the whole site and points to the machine-readable
+ * surfaces.
+ */
+const llmsTxt = `# Argos
+
+> Argos is a visual testing platform: CI uploads screenshots as "builds", Argos diffs them against a baseline, and your team reviews and approves or rejects the detected changes. It keeps product quality high while teams and AI agents ship faster — visual & snapshot testing for Playwright and Storybook.
+
+Pages on argos-ci.com are also available as markdown: send \`Accept: text/markdown\` and the response is \`Content-Type: text/markdown\` (HTML stays the default).
+
+## Documentation
+
+- [Documentation](https://argos-ci.com/docs): guides, SDK references, and concepts
+- [Documentation for LLMs](https://argos-ci.com/docs/llms.txt): the full docs map in markdown (every docs page also exists as .md)
+- [API reference](https://argos-ci.com/docs/api-reference): the Argos REST API at https://api.argos-ci.com/v2
+- [OpenAPI description](https://api.argos-ci.com/v2/openapi.yaml): machine-readable API spec
+- [Agents](https://argos-ci.com/docs/agents): MCP server, CLI, and agent skills
+
+## Agent surfaces
+
+- [MCP server](https://argos-ci.com/docs/agents/mcp-server): official remote MCP server at https://mcp.argos-ci.com (Streamable HTTP, OAuth or personal access token)
+- [MCP server card](https://argos-ci.com/.well-known/mcp/server-card.json): machine-readable server description
+- [API catalog](https://argos-ci.com/.well-known/api-catalog): RFC 9727 linkset of Argos APIs
+- [auth.md](https://argos-ci.com/auth.md): how agents register and authenticate
+- [OAuth protected resource metadata](https://argos-ci.com/.well-known/oauth-protected-resource): RFC 9728
+
+## Product
+
+- [Homepage](https://argos-ci.com/): product overview
+- [Visual testing](https://argos-ci.com/visual-testing): screenshot testing with Playwright
+- [Test debugging](https://argos-ci.com/test-debugging): debug CI failures with screenshots and traces
+- [Flaky test management](https://argos-ci.com/flaky-management): detect and mute flaky changes
+- [Pricing](https://argos-ci.com/pricing): Hobby (free) and Pro plans
+
+## News
+
+- [Blog](https://argos-ci.com/blog): guides and engineering posts
+- [Changelog](https://argos-ci.com/changelog): product updates
+
+## Company
+
+- [About](https://argos-ci.com/about)
+- [Security](https://argos-ci.com/security): SOC 2, GDPR
+- [Status](https://argos.openstatus.dev): uptime and incidents
+`;
+
+export function GET() {
+  return new Response(llmsTxt, { headers: markdownHeaders(llmsTxt) });
+}

--- a/app/markdown/home.md
+++ b/app/markdown/home.md
@@ -1,0 +1,53 @@
+# Argos — Review product changes in the age of AI
+
+> Argos keeps product quality high while your team and your agents ship faster. See every change a PR makes, whether pixels, Markdown, or JSON, review it with confidence, and deploy every PR. Visual & snapshot testing for Playwright and Storybook.
+
+Canonical: https://argos-ci.com/
+Machine-readable map: https://argos-ci.com/llms.txt
+
+Agents generate more changes than teams can review. Argos makes every change
+obvious, then lets your team and your agents comment, approve, and ship.
+
+## What Argos does
+
+- **Visual testing** — Your CI uploads screenshots as "builds"; Argos diffs
+  them against the approved baseline and flags every visual change on the pull
+  request. First-class SDKs for Playwright and Storybook, plus a CLI that works
+  with any screenshot folder.
+- **Collaborative reviews** — Approve or reject changes from a purpose-built
+  review UI, comment on specific changes, and keep GitHub/GitLab checks in
+  sync. Keep your team on the same page.
+- **Agent-ready** — Your agents check their own work: through the
+  [Argos MCP server](https://argos-ci.com/docs/agents/mcp-server), agents read
+  what their change did, fix what they broke, and only bring you what's left.
+- **Deploy Storybook on every PR** — Argos hosts your Storybook builds so every
+  pull request has a browsable component preview.
+- **Flaky test management** — Argos detects unstable changes, lets you ignore
+  them, and keeps flakiness from blocking reviews.
+- **Test debugging** — Screenshots, DOM snapshots, and Playwright traces
+  attached to every failure, so CI failures are diagnosed in seconds.
+- **Cost** — Cut visual testing costs, not coverage: 5,000 free screenshots per
+  month on Hobby, transparent per-screenshot pricing on Pro
+  (see [pricing](https://argos-ci.com/pricing)).
+
+## Integrations
+
+GitHub, GitLab, Playwright, Storybook, Cypress, Puppeteer, WebdriverIO, and
+any CI. Trusted by teams like MUI, Le Monde, Doctolib, and Interactive Things
+([customers](https://argos-ci.com/customers)).
+
+## For agents
+
+- Docs: https://argos-ci.com/docs (markdown map: https://argos-ci.com/docs/llms.txt)
+- REST API: https://api.argos-ci.com/v2 (OpenAPI: https://api.argos-ci.com/v2/openapi.yaml)
+- MCP server: https://mcp.argos-ci.com
+- How to authenticate: https://argos-ci.com/auth.md
+- API catalog: https://argos-ci.com/.well-known/api-catalog
+
+## Get started
+
+1. Sign up at https://app.argos-ci.com/signup (GitHub, GitLab, or Google).
+2. Install an SDK: `npm install @argos-ci/playwright` (or `@argos-ci/storybook`, `@argos-ci/cli`).
+3. Upload screenshots from CI and review changes on every pull request.
+
+Quickstart: https://argos-ci.com/docs/quickstart

--- a/app/md/[[...slug]]/route.ts
+++ b/app/md/[[...slug]]/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+
+import { markdownHeaders } from "@/lib/agents";
+import { getPageMarkdown } from "@/lib/markdown";
+
+/**
+ * Markdown representations of the site's pages ("Markdown for Agents").
+ * Requests that prefer `Accept: text/markdown` are rewritten here by
+ * proxy.ts; the /md/* URLs also work when fetched directly.
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug = [] } = await context.params;
+  const markdown = await getPageMarkdown(slug.join("/"));
+  if (markdown === null) {
+    const notFound =
+      "# Not found\n\nThis page has no markdown representation.\n";
+    return new Response(notFound, {
+      status: 404,
+      headers: markdownHeaders(notFound),
+    });
+  }
+  return new Response(markdown, { headers: markdownHeaders(markdown) });
+}

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,4 +1,12 @@
+# Content Signals (https://contentsignals.org/)
+# search: build a search index and show links/snippets from it
+# ai-input: use content as input to AI (grounding, RAG, agents)
+# ai-train: use content to train or fine-tune AI models
+# Argos wants to be found and understood by humans and agents alike.
+
 User-agent: *
+
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 Allow: /
 

--- a/components/WebMcp.tsx
+++ b/components/WebMcp.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  ARGOS_HOBBY_SCREENSHOT_COUNT,
+  ARGOS_PRO_FLAT_PRICE,
+  ARGOS_PRO_FLAT_SCREENSHOT_COUNT,
+  ARGOS_SCREENSHOT_PRICE,
+  ARGOS_STORYBOOK_SCREENSHOT_PRICE,
+} from "@/lib/constants";
+
+/**
+ * WebMCP (https://webmachinelearning.github.io/webmcp/): expose the site's
+ * key information as tools to browser-embedded AI agents. No-op in browsers
+ * without `navigator.modelContext`.
+ */
+
+type ToolContent = { type: "text"; text: string };
+
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => Promise<{
+    content: ToolContent[];
+  }>;
+};
+
+type ModelContext = {
+  registerTool?: (tool: WebMcpTool) => { unregister?: () => void } | void;
+  provideContext?: (context: { tools: WebMcpTool[] }) => void;
+};
+
+const NO_ARGS_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+function text(content: string): { content: ToolContent[] } {
+  return { content: [{ type: "text", text: content }] };
+}
+
+async function fetchText(url: string, accept?: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: accept ? { accept } : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(`Fetching ${url} failed with status ${response.status}`);
+  }
+  return response.text();
+}
+
+const tools: WebMcpTool[] = [
+  {
+    name: "get_argos_overview",
+    description:
+      "Get an overview of Argos (visual testing platform): what it does, integrations, and links to docs, API, and MCP server, as markdown.",
+    inputSchema: NO_ARGS_SCHEMA,
+    execute: async () => text(await fetchText("/llms.txt")),
+  },
+  {
+    name: "get_pricing",
+    description:
+      "Get Argos pricing. Optionally pass screenshotsPerMonth to estimate the monthly cost of the Pro plan for that usage.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        screenshotsPerMonth: {
+          type: "number",
+          description: "Expected number of screenshots uploaded per month.",
+        },
+      },
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const lines = [
+        `Hobby: free, up to ${ARGOS_HOBBY_SCREENSHOT_COUNT.toLocaleString("en-US")} screenshots/month.`,
+        `Pro: $${ARGOS_PRO_FLAT_PRICE}/month flat, includes ${ARGOS_PRO_FLAT_SCREENSHOT_COUNT.toLocaleString("en-US")} screenshots, then $${ARGOS_SCREENSHOT_PRICE} per extra screenshot ($${ARGOS_STORYBOOK_SCREENSHOT_PRICE} for Storybook screenshots).`,
+        `Enterprise: custom volume, SLA, and SSO — https://argos-ci.com/contact/sale.`,
+      ];
+      const count = args.screenshotsPerMonth;
+      if (typeof count === "number" && Number.isFinite(count) && count >= 0) {
+        const extra = Math.max(0, count - ARGOS_PRO_FLAT_SCREENSHOT_COUNT);
+        const price = ARGOS_PRO_FLAT_PRICE + extra * ARGOS_SCREENSHOT_PRICE;
+        lines.push(
+          `Estimate for ${count.toLocaleString("en-US")} screenshots/month on Pro: $${price.toFixed(2)}/month.`,
+        );
+      }
+      lines.push("Details: https://argos-ci.com/pricing");
+      return text(lines.join("\n"));
+    },
+  },
+  {
+    name: "get_latest_changelog",
+    description:
+      "Get the Argos changelog (recent product updates and new features) as markdown.",
+    inputSchema: NO_ARGS_SCHEMA,
+    execute: async () => text(await fetchText("/changelog", "text/markdown")),
+  },
+  {
+    name: "get_mcp_connection_info",
+    description:
+      "How to connect an AI agent to Argos: MCP server endpoint, authentication methods, and API endpoints.",
+    inputSchema: NO_ARGS_SCHEMA,
+    execute: async () => text(await fetchText("/auth.md")),
+  },
+];
+
+export function WebMcp() {
+  React.useEffect(() => {
+    const modelContext = (
+      navigator as Navigator & { modelContext?: ModelContext }
+    ).modelContext;
+    if (!modelContext) {
+      return undefined;
+    }
+    if (typeof modelContext.registerTool === "function") {
+      const registrations = tools.map((tool) =>
+        modelContext.registerTool!(tool),
+      );
+      return () => {
+        for (const registration of registrations) {
+          registration?.unregister?.();
+        }
+      };
+    }
+    if (typeof modelContext.provideContext === "function") {
+      modelContext.provideContext({ tools });
+    }
+    return undefined;
+  }, []);
+  return null;
+}

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical URLs of the machine-facing Argos surfaces, shared by the
+ * agent-facing documents the site serves (auth.md, llms.txt, the markdown
+ * representations). One module so they can't drift apart from each other.
+ *
+ * The well-known discovery documents themselves (API catalog, OAuth protected
+ * resource metadata, MCP server card) are served by the backend on
+ * app.argos-ci.com — this site's /.well-known/* redirect points there.
+ */
+
+export const SITE_URL = "https://argos-ci.com";
+
+/** Base URL of the Argos REST API. */
+export const API_URL = "https://api.argos-ci.com/v2";
+
+/** Human documentation of the REST API. */
+export const API_DOCS_URL = "https://argos-ci.com/docs/api-reference";
+
+/** Official remote MCP server (Streamable HTTP). */
+export const MCP_URL = "https://mcp.argos-ci.com";
+
+/** Human documentation of the MCP server. */
+export const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
+
+/**
+ * OAuth 2.1 authorization server that issues tokens for the REST API and the
+ * MCP server. Serves RFC 8414 metadata at
+ * https://app.argos-ci.com/.well-known/oauth-authorization-server
+ * (argos-ci.com/.well-known/oauth-authorization-server redirects there).
+ */
+export const OAUTH_ISSUER = "https://app.argos-ci.com";
+
+/**
+ * OAuth scopes accepted by the API and the MCP server. Mirrors
+ * `scopes_supported` in the authorization server metadata — update both
+ * together (source of truth: the argos backend).
+ */
+export const OAUTH_SCOPES = [
+  "profile",
+  "projects:read",
+  "projects:write",
+  "builds:write",
+  "reviews:write",
+  "comments:read",
+  "comments:write",
+  "account:admin",
+];
+
+/** Rough token count of a markdown document, for `x-markdown-tokens`. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Response headers for markdown served to agents. `X-Robots-Tag: noindex`
+ * keeps the markdown variants out of search indexes (the HTML pages are the
+ * canonical documents).
+ */
+export function markdownHeaders(text: string): HeadersInit {
+  return {
+    "Content-Type": "text/markdown; charset=utf-8",
+    "x-markdown-tokens": String(estimateTokens(text)),
+    Vary: "Accept",
+    "X-Robots-Tag": "noindex",
+    "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+  };
+}

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,238 @@
+import * as matter from "gray-matter";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { SITE_URL } from "./agents";
+import { Categories, checkIsCategorySlug, getArticles } from "./api/blog";
+import { getArticleBySlug } from "./api/blog";
+import {
+  getChangelogEntries,
+  getChangelogEntryBySlug,
+  getChangelogFiles,
+} from "./api/changelog";
+import {
+  ARGOS_HOBBY_SCREENSHOT_COUNT,
+  ARGOS_PRO_FLAT_PRICE,
+  ARGOS_PRO_FLAT_SCREENSHOT_COUNT,
+  ARGOS_SCREENSHOT_PRICE,
+  ARGOS_STORYBOOK_SCREENSHOT_PRICE,
+  GITHUB_SSO_PRICE,
+  SAML_SSO_PRICE,
+} from "./constants";
+
+/**
+ * Markdown representations of the site's pages, served when a request prefers
+ * `Accept: text/markdown` (see proxy.ts) or hits /md/* directly. Blog articles
+ * and changelog entries come from their MDX sources; static marketing pages
+ * are curated documents in app/markdown/.
+ *
+ * Publish scheduling is enforced by reusing getArticleBySlug /
+ * getChangelogEntryBySlug, which hide content whose date has not elapsed.
+ */
+
+/** Standard document header so every markdown page is self-describing. */
+function docHeader(props: {
+  title: string;
+  description?: string;
+  canonical: string;
+  date?: string;
+}): string {
+  const lines = [`# ${props.title}`, ""];
+  if (props.description) {
+    lines.push(`> ${props.description}`, "");
+  }
+  if (props.date) {
+    lines.push(`Published: ${props.date.split("T")[0]}`);
+  }
+  lines.push(`Canonical: ${props.canonical}`, "");
+  return lines.join("\n");
+}
+
+/**
+ * Reduce an MDX source to plain markdown: drop the frontmatter and the
+ * top-level import/export statements. Our articles and changelog entries are
+ * otherwise plain markdown.
+ */
+function mdxToMarkdown(source: string): string {
+  const { content } = matter.default(source);
+  return content
+    .replace(/^(import|export)\s[^\n]*(\n|$)/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function readCuratedPage(name: string): Promise<string> {
+  const filepath = join(process.cwd(), "app", "markdown", name);
+  return readFile(filepath, "utf-8");
+}
+
+async function getLegalMarkdown(page: "privacy" | "terms"): Promise<string> {
+  const source = await readCuratedPage(`${page}.mdx`);
+  const title = page === "privacy" ? "Privacy policy" : "Terms of service";
+  return [
+    docHeader({ title, canonical: `${SITE_URL}/${page}` }),
+    mdxToMarkdown(source),
+    "",
+  ].join("\n");
+}
+
+async function getArticleMarkdown(slug: string): Promise<string | null> {
+  const article = await getArticleBySlug(slug);
+  if (!article) {
+    return null;
+  }
+  const source = await readFile(article.filepath, "utf-8");
+  return [
+    docHeader({
+      title: article.title,
+      description: article.description,
+      canonical: `${SITE_URL}/blog/${article.slug}`,
+      date: article.date,
+    }),
+    `Author: ${article.author.name} · Category: ${article.category.title}`,
+    "",
+    mdxToMarkdown(source),
+    "",
+  ].join("\n");
+}
+
+async function getChangelogMarkdown(urlSlug: string): Promise<string | null> {
+  const entry = await getChangelogEntryBySlug(urlSlug);
+  if (!entry) {
+    return null;
+  }
+  const source = await readFile(entry.filepath, "utf-8");
+  return [
+    docHeader({
+      title: entry.title,
+      description: entry.description,
+      canonical: `${SITE_URL}/changelog/${urlSlug}`,
+      date: entry.date,
+    }),
+    mdxToMarkdown(source),
+    "",
+  ].join("\n");
+}
+
+async function getBlogIndexMarkdown(category?: string): Promise<string | null> {
+  if (category && !checkIsCategorySlug(category)) {
+    return null;
+  }
+  const articles = await getArticles(
+    category && checkIsCategorySlug(category) ? { category } : undefined,
+  );
+  const title = category
+    ? Categories[category as keyof typeof Categories].pageTitle
+    : "Argos Blog";
+  const lines = [
+    docHeader({
+      title,
+      description:
+        "Guides, product news, and engineering posts from the Argos team. Every post is available as markdown: request it with `Accept: text/markdown`.",
+      canonical: `${SITE_URL}/blog${category ? `/category/${category}` : ""}`,
+    }),
+  ];
+  for (const article of articles) {
+    lines.push(
+      `- [${article.title}](${SITE_URL}/blog/${article.slug}) — ${article.date.split("T")[0]}`,
+      `  ${article.description}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function getChangelogIndexMarkdown(): Promise<string> {
+  const files = await getChangelogFiles();
+  const entries = await getChangelogEntries(files);
+  const lines = [
+    docHeader({
+      title: "Argos Changelog",
+      description:
+        "New features and improvements shipped in Argos, most recent first. Every entry is available as markdown: request it with `Accept: text/markdown`.",
+      canonical: `${SITE_URL}/changelog`,
+    }),
+  ];
+  for (const entry of entries) {
+    const date = entry.date.split("T")[0];
+    lines.push(
+      `- [${entry.title}](${SITE_URL}/changelog/${date}-${entry.slug}) — ${date}`,
+      `  ${entry.description}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function getPricingMarkdown(): string {
+  return [
+    docHeader({
+      title: "Argos Pricing",
+      description: "Simple pricing that scales with your usage.",
+      canonical: `${SITE_URL}/pricing`,
+    }),
+    `## Hobby — free
+
+For personal projects and experiments.
+
+- Up to ${ARGOS_HOBBY_SCREENSHOT_COUNT.toLocaleString("en-US")} screenshots per month
+- Visual and snapshot testing, GitHub/GitLab integration, community support
+
+## Pro — $${ARGOS_PRO_FLAT_PRICE}/month
+
+For teams. 14-day free trial.
+
+- Includes ${ARGOS_PRO_FLAT_SCREENSHOT_COUNT.toLocaleString("en-US")} screenshots per month
+- Extra screenshots: $${ARGOS_SCREENSHOT_PRICE} each ($${ARGOS_STORYBOOK_SCREENSHOT_PRICE} for Storybook screenshots)
+- Unlimited team members and projects, Slack notifications, priority support
+- Add-ons: GitHub Single Sign-On ($${GITHUB_SSO_PRICE}/month), SAML SSO ($${SAML_SSO_PRICE}/month)
+
+## Enterprise — custom
+
+For organizations with specific needs: custom screenshot volume, 99.99% uptime
+SLA, SSO/SAML, dedicated support, invoicing.
+[Contact us](${SITE_URL}/contact/sale).
+
+Full details and FAQ: ${SITE_URL}/pricing
+`,
+  ].join("\n");
+}
+
+/**
+ * Resolve the markdown representation of a site pathname (without the leading
+ * slash). Returns null when the page has no markdown representation.
+ */
+export async function getPageMarkdown(path: string): Promise<string | null> {
+  const segments = path.split("/").filter(Boolean);
+  const [first, ...rest] = segments;
+
+  if (segments.length === 0) {
+    return readCuratedPage("home.md");
+  }
+
+  switch (first) {
+    case "pricing":
+      return rest.length === 0 ? getPricingMarkdown() : null;
+    case "privacy":
+      return rest.length === 0 ? getLegalMarkdown("privacy") : null;
+    case "terms":
+      return rest.length === 0 ? getLegalMarkdown("terms") : null;
+    case "blog": {
+      if (rest.length === 0 || rest[0] === "page") {
+        return getBlogIndexMarkdown();
+      }
+      if (rest[0] === "category" && rest[1]) {
+        return getBlogIndexMarkdown(rest[1]);
+      }
+      return getArticleMarkdown(rest.join("/"));
+    }
+    case "changelog": {
+      if (rest.length === 0 || rest[0] === "page") {
+        return getChangelogIndexMarkdown();
+      }
+      return getChangelogMarkdown(rest.join("/"));
+    }
+    default:
+      return null;
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,26 @@ const nextConfig = {
   reactStrictMode: false,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   allowedDevOrigins: ["127.0.0.1"],
+  headers: async () => {
+    return [
+      {
+        // Agent discovery (RFC 8288 + RFC 9727 §3): advertise the API catalog
+        // and the machine-readable descriptions of the site from the homepage.
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: [
+              '</.well-known/api-catalog>; rel="api-catalog"',
+              '<https://api.argos-ci.com/v2/openapi.yaml>; rel="service-desc"; type="application/yaml"',
+              '<https://argos-ci.com/docs/api-reference>; rel="service-doc"',
+              '</llms.txt>; rel="describedby"; type="text/markdown"',
+            ].join(", "),
+          },
+        ],
+      },
+    ];
+  },
   redirects: async () => {
     return [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,29 @@ const nextConfig = {
   reactStrictMode: false,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   allowedDevOrigins: ["127.0.0.1"],
+  // The markdown-for-agents route reads MDX sources and curated markdown from
+  // disk at request time; make sure they ship with the serverless function.
+  outputFileTracingIncludes: {
+    "/md/[[...slug]]": [
+      "./articles/**/*.mdx",
+      "./changelogs/**/*.mdx",
+      "./app/markdown/**",
+    ],
+  },
   headers: async () => {
+    // Responses of the pages that support markdown content negotiation
+    // (see proxy.ts) vary on the Accept header.
+    const varyAccept = [
+      "/",
+      "/pricing",
+      "/privacy",
+      "/terms",
+      "/blog/:path*",
+      "/changelog/:path*",
+    ].map((source) => ({
+      source,
+      headers: [{ key: "Vary", value: "Accept" }],
+    }));
     return [
       {
         // Agent discovery (RFC 8288 + RFC 9727 §3): advertise the API catalog
@@ -23,6 +45,7 @@ const nextConfig = {
           },
         ],
       },
+      ...varyAccept,
     ];
   },
   redirects: async () => {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Markdown for Agents: requests that explicitly accept `text/markdown` get
+ * the markdown representation of the page (served by app/md/[[...slug]]);
+ * browsers keep getting HTML. Only runs on routes that have a markdown
+ * representation (see matcher + lib/markdown.ts).
+ */
+export default function proxy(request: NextRequest) {
+  const accept = request.headers.get("accept") ?? "";
+  if (accept.includes("text/markdown")) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/md${url.pathname === "/" ? "" : url.pathname}`;
+    const response = NextResponse.rewrite(url);
+    response.headers.set("Vary", "Accept");
+    return response;
+  }
+  const response = NextResponse.next();
+  response.headers.set("Vary", "Accept");
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/",
+    "/pricing",
+    "/privacy",
+    "/terms",
+    "/blog/:path*",
+    "/changelog/:path*",
+  ],
+};


### PR DESCRIPTION
Make argos-ci.com agent-ready, addressing an [isitagentready.com](https://isitagentready.com) scan. One commit per subject; every document is grounded in surfaces Argos actually ships.

**Companion PR: [argos-ci/argos#2449](https://github.com/argos-ci/argos/pull/2449)** — the well-known discovery documents (API catalog, OAuth protected resource metadata, MCP server card) are served by the backend on app.argos-ci.com, behind this site's existing `/.well-known/* → app.argos-ci.com` redirect, which stays untouched. The two PRs deploy independently: the redirect is already live in production, so each side lights up on its own.

## What this PR adds to the site

| Surface | Standard | Where |
| --- | --- | --- |
| `Link` headers on `/` (`api-catalog`, `service-desc`, `service-doc`, `describedby`) | RFC 8288 / RFC 9727 §3 | `next.config.mjs` `headers()` |
| `/auth.md` — agent registration guide (OAuth 2.1 + RFC 7591 dynamic client registration, PATs, scopes, revocation) | [Auth.md](https://workos.com/auth-md) | `app/auth.md/` |
| `Content-Signal: search=yes, ai-input=yes, ai-train=yes` | [Content Signals](https://contentsignals.org/) | `app/robots.txt` |
| `/llms.txt` site map for agents | [llmstxt.org](https://llmstxt.org/) | `app/llms.txt/` |
| Markdown content negotiation: `Accept: text/markdown` → `text/markdown` + `x-markdown-tokens` + `Vary: Accept` | [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) | `proxy.ts`, `app/md/[[...slug]]/`, `lib/markdown.ts` |
| WebMCP: 4 tools registered on `navigator.modelContext` at page load | [WebMCP](https://webmachinelearning.github.io/webmcp/) | `components/WebMcp.tsx` |

Shared canonical URLs live in `lib/agents.ts` so the documents can't drift apart.

## Notes for review

- **Markdown coverage**: homepage (curated `app/markdown/home.md`), pricing (generated from `lib/constants.ts`), privacy/terms (from their MDX), all blog articles + changelog entries (from MDX sources), `/blog` + `/changelog` indexes. Scheduled content is honored — unpublished pages 404 in the prod build.
- **`Content-Signal: ai-train=yes` is a deliberate choice to review**: it fits the AI-visibility strategy, flip to `no` if we'd rather not signal training permission.
- The homepage `Link: </.well-known/api-catalog>; rel="api-catalog"` points at the redirect; RFC 9727 explicitly allows the well-known URI to redirect.

## Not in this PR

DNS-AID needs records in Cloudflare (plus enabling DNSSEC — no DS record exists today):

```
_index._agents.argos-ci.com. 3600 IN HTTPS 1 mcp.argos-ci.com. alpn="h2,http/1.1"
_mcp._agents.argos-ci.com.   3600 IN HTTPS 1 mcp.argos-ci.com. alpn="h2,http/1.1"
```

The `agent_auth` block for the authorization server metadata is a separate in-flight branch in the argos repo (`greg/oauth-agent-auth`).

## Test plan

- `tsc --noEmit` and Prettier clean; production build green.
- curl sweep against `next start`: `/.well-known/*` (including `api-catalog`) 307s to app.argos-ci.com with the path intact; `auth.md` and `llms.txt` serve `text/markdown`; markdown negotiation returns `text/markdown` on `Accept: text/markdown` while HTML stays the default; `Content-Signal` present in robots.txt.
- WebMCP verified with a Playwright run shimming `navigator.modelContext` before page scripts (as the scanner does): 4 tools register, `get_pricing` computes a $160/mo estimate for 50k screenshots, `get_latest_changelog` round-trips the site's own markdown negotiation.
- Repo Playwright suite: 43/44 passed, the one failure was a `page.goto` load timeout under parallel local load and passes standalone.
- After both PRs deploy: re-scan on isitagentready.com (only DNS-AID should remain until the Cloudflare records land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)