### PR TITLE
Simplify the three media sharing feature cards

### DIFF
--- a/app/markdown/media-sharing.md
+++ b/app/markdown/media-sharing.md
@@ -42,9 +42,9 @@ nobody intended, media shows the result someone did intend.
   screenshot typically travels at a tenth of the size); `--no-compress` opts
   out. Argos never rewrites the stored file server-side, so a media is usable
   the moment the upload finishes.
-- A **video** embeds as its poster frame wrapped in a link to the share page,
-  the only form GitHub renders. The poster is derived from the video itself and
-  available immediately.
+- A **video** embeds as a thumbnail linked to the share page, the only form
+  GitHub renders. The thumbnail is a poster frame derived from the video itself
+  and available immediately.
 
 ## Quickstart
 

--- a/app/media-sharing/page.tsx
+++ b/app/media-sharing/page.tsx
@@ -175,37 +175,20 @@ export default function Page() {
           className="relative grid grid-cols-1 border-x border-b max-md:divide-y md:grid-cols-3 md:divide-x"
         >
           <FeatureGridFeatureSmall
-            title="Videos that render on GitHub"
-            description={
-              <>
-                MP4, WebM, and MOV up to 500 MB. The embed is a poster frame
-                linked to the share page, derived from the video itself and
-                available instantly.
-              </>
-            }
+            title="Videos work too"
+            description="Record a demo video and the pull request shows a thumbnail that opens the recording. MP4, WebM, and MOV, up to 500 MB."
             href="/docs/learn/media/standalone-media-upload#embedding-the-result"
             icon={FilmIcon}
           />
           <FeatureGridFeatureSmall
-            title="Every surface an agent has"
-            description={
-              <>
-                CLI, Node.js SDK, REST API, and MCP tools under the{" "}
-                <code>media:read</code> and <code>media:write</code> scopes. The
-                same flow everywhere.
-              </>
-            }
+            title="Works with any agent"
+            description="CLI, Node.js SDK, REST API, and MCP. Whatever your agent already uses, uploading is a single call."
             href="/docs/learn/media/standalone-media-upload#from-an-ai-agent"
             icon={BotIcon}
           />
           <FeatureGridFeatureSmall
-            title="Private by default, safe to paste"
-            description={
-              <>
-                Team-scoped share pages on Pro, unguessable URLs, no indexing,
-                and plan-based retention: 30 days on Hobby, 1 year on Pro.
-              </>
-            }
+            title="Private by default"
+            description="Links are unguessable and never indexed by search engines. On Pro, only your team can open them. Kept 30 days on Hobby, 1 year on Pro."
             href="/docs/learn/media/share-links-retention-and-limits"
             icon={LockIcon}
           />


### PR DESCRIPTION
The three small cards on `/media-sharing` explained the mechanism rather than the benefit. This rewrites them in plain language: no more "poster frame", `media:read`/`media:write` scopes, or "team-scoped"/"plan-based retention". Same facts, easier to grasp at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)