### PR TITLE
Add an inline Code component for snippets in prose

### DIFF
--- a/app/collaborative-reviews/page.tsx
+++ b/app/collaborative-reviews/page.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { Button } from "@/components/Button";
 import { CallToActionSection } from "@/components/CallToActionSection";
 import { Chip } from "@/components/Chip";
+import { Code } from "@/components/Code";
 import { Container } from "@/components/Container";
 import { FeatureIndicator } from "@/components/feature-section/FeatureSection";
 import {
@@ -187,9 +188,9 @@ export default function Page() {
             title="Markdown & slash commands"
             description={
               <>
-                Comments are written in Markdown with{" "}
-                <code className="font-mono">/</code> slash commands and
-                @mentions. Drafts persist locally so you never lose a thought.
+                Comments are written in Markdown with <Code>/</Code> slash
+                commands and @mentions. Drafts persist locally so you never lose
+                a thought.
               </>
             }
             href="/docs/learn/review-workflow/review-a-build"

--- a/app/compare/backstopjs/faq.tsx
+++ b/app/compare/backstopjs/faq.tsx
@@ -1,3 +1,4 @@
+import { Code } from "@/components/Code";
 import { FAQAccordion, FAQQuestion } from "@/components/FAQAccordion";
 import { Link } from "@/components/Link";
 
@@ -9,7 +10,7 @@ export function FAQ() {
         <>
           <p>
             <strong>BackstopJS</strong> is a self-hosted tool: you describe
-            scenarios in <code>backstop.json</code>, capture baselines to a
+            scenarios in <Code>backstop.json</Code>, capture baselines to a
             local folder, and diff them on your machine or CI.
           </p>
           <p>
@@ -30,7 +31,7 @@ export function FAQ() {
           <p>
             You translate them into a small Playwright test: scenario URLs and
             selectors become <strong>argosScreenshot()</strong> calls, and{" "}
-            <code>viewports</code> become responsive viewports. The{" "}
+            <Code>viewports</Code> become responsive viewports. The{" "}
             <Link href="/docs/learn/how-to-guides/migrate-to-argos/from-backstopjs">
               migration guide
             </Link>{" "}
@@ -46,8 +47,8 @@ export function FAQ() {
       answer: (
         <p>
           In the cloud. BackstopJS stores baselines in a local{" "}
-          <code>bitmaps_reference/</code> folder and approves with{" "}
-          <code>backstop approve</code> on one machine. Argos stores baselines
+          <Code>bitmaps_reference/</Code> folder and approves with{" "}
+          <Code>backstop approve</Code> on one machine. Argos stores baselines
           from your Git history and lets your whole team review and approve
           changes on the pull request, with full history.
         </p>

--- a/app/compare/playwright/faq.tsx
+++ b/app/compare/playwright/faq.tsx
@@ -1,3 +1,4 @@
+import { Code } from "@/components/Code";
 import { FAQAccordion, FAQQuestion } from "@/components/FAQAccordion";
 import { Link } from "@/components/Link";
 
@@ -50,8 +51,8 @@ export function FAQ() {
       answer: (
         <>
           <p>
-            Yes. Native snapshots are platform-specific (<code>-darwin</code> vs{" "}
-            <code>-linux</code>), so teams run them only in Docker or CI to stay
+            Yes. Native snapshots are platform-specific (<Code>-darwin</Code> vs{" "}
+            <Code>-linux</Code>), so teams run them only in Docker or CI to stay
             consistent. Argos renders and compares in the cloud the same way
             every run, so you are not fighting environment mismatches.
           </p>

--- a/app/deployments/page.tsx
+++ b/app/deployments/page.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { Button } from "@/components/Button";
 import { CallToActionSection } from "@/components/CallToActionSection";
 import { Chip } from "@/components/Chip";
+import { Code } from "@/components/Code";
 import { Container } from "@/components/Container";
 import { FeatureIndicator } from "@/components/feature-section/FeatureSection";
 import {
@@ -61,10 +62,9 @@ export default function Page() {
             </div>
             <HeroHeading>Deploy Storybook on every pull request</HeroHeading>
             <HeroDescription>
-              Run <code className="font-mono">argos deploy</code> and get a
-              live, shareable URL for every PR. Preview what your team and your
-              agents built before you merge, with no extra infrastructure to
-              maintain.
+              Run <Code>argos deploy</Code> and get a live, shareable URL for
+              every PR. Preview what your team and your agents built before you
+              merge, with no extra infrastructure to maintain.
             </HeroDescription>
             <HeroActions>
               <Button size="large" asChild>
@@ -110,12 +110,9 @@ export default function Page() {
               title={<>A preview URL on every PR</>}
               description={
                 <>
-                  <code className="font-mono">
-                    argos deploy ./storybook-static
-                  </code>{" "}
-                  ships your build to a unique, immutable URL, perfect for
-                  sharing a change with reviewers, designers, or an agent before
-                  it merges.
+                  <Code>argos deploy ./storybook-static</Code> ships your build
+                  to a unique, immutable URL, perfect for sharing a change with
+                  reviewers, designers, or an agent before it merges.
                 </>
               }
               href="/docs/learn/deployments"

--- a/app/media-sharing/faq.tsx
+++ b/app/media-sharing/faq.tsx
@@ -1,3 +1,4 @@
+import { Code } from "@/components/Code";
 import { FAQQuestion } from "@/components/FAQAccordion";
 import { Link } from "@/components/Link";
 
@@ -10,7 +11,7 @@ export const MEDIA_SHARING_QUESTIONS: FAQQuestion[] = [
           GitHub has no public API for comment attachments. Dragging an image
           into a pull request needs a signed-in browser session, which an agent
           or a CI job doesn&apos;t have. With Argos,{" "}
-          <code>argos media upload --branch</code> stages the file from the
+          <Code>argos media upload --branch</Code> stages the file from the
           terminal, and when a pull request opens for that branch, Argos posts
           it there in a managed comment, automatically.
         </p>
@@ -97,8 +98,8 @@ export const MEDIA_SHARING_QUESTIONS: FAQQuestion[] = [
         <p>
           A reviewer pins a comment to a point on the image, and the pin is
           stored as normalized coordinates with the exact version it was written
-          on. The agent runs <code>argos media list --branch</code> to find its
-          uploads, <code>argos media comment list</code> to read the open
+          on. The agent runs <Code>argos media list --branch</Code> to find its
+          uploads, <Code>argos media comment list</Code> to read the open
           threads, then replies and resolves each one from the same CLI. Even a
           process that cannot see pixels can act on the feedback.
         </p>

--- a/app/media-sharing/page.tsx
+++ b/app/media-sharing/page.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/Badge";
 import { Button } from "@/components/Button";
 import { CallToActionSection } from "@/components/CallToActionSection";
 import { Chip } from "@/components/Chip";
+import { Code } from "@/components/Code";
 import { CodeBlock } from "@/components/CodeBlock";
 import { Container } from "@/components/Container";
 import { FAQAccordion } from "@/components/FAQAccordion";
@@ -134,7 +135,7 @@ export default function Page() {
             title={<>Before and after, one link</>}
             description={
               <>
-                Name two files <code>-before</code> and <code>-after</code> and
+                Name two files <Code>-before</Code> and <Code>-after</Code> and
                 they share one identity: a single row in the pull request
                 comment, and a share page that compares both sides with synced
                 pan and zoom. The reviewer sees the change, not two tabs.
@@ -161,7 +162,7 @@ export default function Page() {
             description={
               <>
                 A media is an identity; every upload is a version of it.
-                Re-uploading <code>checkout.png</code> updates the Markdown
+                Re-uploading <Code>checkout.png</Code> updates the Markdown
                 already pasted in the pull request, keeps the version a reviewer
                 commented on underneath, and identical bytes cost nothing.
               </>

--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+import type { ComponentPropsWithRef } from "react";
+
+/**
+ * Inline code inside a sentence. The mono face alone doesn't say where a
+ * snippet starts and stops, so it carries a faint tint and a hairline: enough
+ * to read as one object, not enough to pull the eye off the line.
+ *
+ * Everything is sized in `em` so it fits whatever type it sits in, and the
+ * `content-none` pair drops the backticks the typography plugin adds inside
+ * `prose`.
+ */
+export function Code(props: ComponentPropsWithRef<"code">) {
+  return (
+    <code
+      {...props}
+      className={clsx(
+        "rounded-[0.35em] border-[0.5px] border-(--neutral-a4) bg-(--neutral-a3) px-[0.35em] py-[0.1em] font-mono text-[0.9em] font-normal break-words box-decoration-clone before:content-none after:content-none",
+        props.className,
+      )}
+    />
+  );
+}


### PR DESCRIPTION
Inline `<code>` only got a mono face, so a snippet in a sentence had no visible start or end. `Code` gives it a faint tint and a hairline, sized in `em` so it fits the hero, a feature description or a FAQ answer alike. It wraps cleanly on mobile and drops the backticks the typography plugin adds inside `prose`.

Every raw `<code>` in the marketing pages now goes through it. Copy is unchanged, so the markdown twins stay as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)