### PR TITLE
Point the media sharing illustrations at a live example

### DIFF
--- a/app/markdown/media-sharing.md
+++ b/app/markdown/media-sharing.md
@@ -22,7 +22,7 @@ A live example, public and real:
 https://github.com/argos-ci/snkr-shop/pull/5 is a pull request whose branch
 had two before/after pairs staged; Argos posted them in the single managed
 comment when the pull request opened.
-https://app.argos-ci.com/m/k2qshjz9b2486gcpij9n is the share page for one of
+https://app.argos-ci.com/m/mp21qmkhpekfx1v4ot7r is the share page for one of
 them, opening on the before/after compare view.
 
 ## How it works

--- a/app/markdown/media-sharing.md
+++ b/app/markdown/media-sharing.md
@@ -18,6 +18,13 @@ a build. It complements
 [visual testing](https://argos-ci.com/visual-testing): builds catch the changes
 nobody intended, media shows the result someone did intend.
 
+A live example, public and real:
+https://github.com/argos-ci/snkr-shop/pull/5 is a pull request whose branch
+had two before/after pairs staged; Argos posted them in the single managed
+comment when the pull request opened.
+https://app.argos-ci.com/m/k2qshjz9b2486gcpij9n is the share page for one of
+them, opening on the before/after compare view.
+
 ## How it works
 
 - A **media** is an identity (what the picture is of), and every upload is a

--- a/app/media-sharing/features/BeforeAfterPair.tsx
+++ b/app/media-sharing/features/BeforeAfterPair.tsx
@@ -1,8 +1,9 @@
-import { LockIcon } from "lucide-react";
+import { GlobeIcon } from "lucide-react";
 
-import { ApplicationSVG } from "@/components/ApplicationSVG";
 import { Card } from "@/components/Card";
 import { Chip } from "@/components/Chip";
+
+import { Storefront } from "./Storefront";
 
 /**
  * The share page with a before/after pair, compressed to its essentials: the
@@ -10,6 +11,12 @@ import { Chip } from "@/components/Chip";
  * and — in the footer — the naming trick that produced them. The two file
  * names are the feature: suffix a name with `-before`/`-after` and the pair
  * shares one identity, one link, one comment row.
+ *
+ * This is the live example's actual pair — sneakers-listing.png from
+ * snkr-shop#5 — so the "See it live" action under the card opens the page
+ * this drawing compresses, in the same compare view. The pill says "Public
+ * link" rather than the Pro default "Team only" for the same reason: the
+ * page it opens is public, and a visitor should not be told otherwise.
  */
 export function BeforeAfterPair() {
   return (
@@ -18,29 +25,32 @@ export function BeforeAfterPair() {
       className="w-full max-w-md animate-slide-up-fade overflow-hidden animate-duration-500 fill-mode-both motion-reduce:animate-fade-in"
     >
       <div className="flex items-center gap-2 border-b-[0.5px] px-3 py-2">
-        <span className="font-mono text-xs font-medium">checkout.png</span>
-        <span className="font-mono text-xxs text-low max-sm:hidden">
-          1440x900 · 25 KB
+        <span className="min-w-0 truncate font-mono text-xs font-medium">
+          sneakers-listing.png
         </span>
-        <Chip icon={LockIcon} className="ml-auto text-xxs">
-          Team only
+        <span className="font-mono text-xxs text-low max-sm:hidden">
+          2880x2160
+        </span>
+        <Chip icon={GlobeIcon} className="ml-auto shrink-0 text-xxs">
+          Public link
         </Chip>
       </div>
       <div className="grid grid-cols-2 divide-x-[0.5px] bg-subtle">
         <Pane label="Before">
-          <ApplicationSVG className="w-full" />
+          <Storefront variant="before" />
         </Pane>
         <Pane label="After">
-          <ApplicationSVG className="w-full" withChanges="success" />
+          <Storefront variant="after" />
         </Pane>
       </div>
-      <div className="flex items-center justify-between gap-2 border-t-[0.5px] px-3 py-2 text-xxs">
+      {/* The naming trick that produced the pair, and nothing else: the old
+          "one link, synced zoom" tag duplicated the copy under the card and
+          its space is what let the second file name truncate away. */}
+      <div className="flex items-center border-t-[0.5px] px-3 py-2 text-xxs">
         <span className="truncate font-mono text-low">
-          checkout-<span className="text-(--plum-11)">before</span>.png ·
-          checkout-<span className="text-(--plum-11)">after</span>.png
-        </span>
-        <span className="shrink-0 text-low max-sm:hidden">
-          one link, synced zoom
+          sneakers-listing-<span className="text-(--plum-11)">before</span>.png
+          · sneakers-listing-<span className="text-(--plum-11)">after</span>
+          .png
         </span>
       </div>
     </Card>

--- a/app/media-sharing/features/MediaFlow.tsx
+++ b/app/media-sharing/features/MediaFlow.tsx
@@ -1,13 +1,16 @@
 import clsx from "clsx";
-import { GitPullRequestIcon } from "lucide-react";
+import { ArrowUpRightIcon, GitPullRequestIcon } from "lucide-react";
 import type { ComponentPropsWithoutRef } from "react";
 
-import { AgentTerminal, Ref } from "@/components/AgentTerminal";
+import { AgentTerminal } from "@/components/AgentTerminal";
 import { ArgosEmblem } from "@/components/ArgosEmblem";
 import { Badge } from "@/components/Badge";
 import { Card } from "@/components/Card";
 import { Chip } from "@/components/Chip";
 import { SmallTitle } from "@/components/Typography";
+
+import { LIVE_EXAMPLE_PR_URL, LIVE_EXAMPLE_SHARE_URL } from "../live-example";
+import { Storefront } from "./Storefront";
 
 /**
  * The whole story in one glance: an agent uploading from the branch it is
@@ -18,6 +21,11 @@ import { SmallTitle } from "@/components/Typography";
  * features to compare; they are one flow with a wait in the middle, and the
  * badge on the line is the actor: Argos publishes, not the agent. Nothing on
  * the right card is something the uploader did.
+ *
+ * Nothing here is invented: this is snkr-shop#5, a real public pull request,
+ * drawn. The session's share link opens the actual share page and the pull
+ * request card opens the actual PR, so every claim the drawing makes is one
+ * click from being checked — the caption under it, in page.tsx, says so.
  *
  * The left card is a Claude Code session rather than a shell prompt, because
  * the page claims an agent does this and nobody hand-types `argos media
@@ -59,6 +67,11 @@ export function MediaFlow() {
  * call and not its result, so the Argos CLI is visibly doing the work without
  * the panel turning into a transcript.
  *
+ * The share link is the live example's real URL and actually opens it — the
+ * one place in the session where the reader can step out of the illustration
+ * and into the product. It is underlined for that reason; the plain accent
+ * `Ref` used elsewhere marks a reference, and this is an exit.
+ *
  * It stops before the payoff on purpose. That the media reaches the pull
  * request is drawn twice already — the badge on the line and the card it points
  * at — and a panel that narrates what the illustration around it shows is the
@@ -67,7 +80,7 @@ export function MediaFlow() {
 function AgentSession(props: { className?: string }) {
   return (
     <AgentTerminal
-      prompt="Redesign the checkout page"
+      prompt="Add quick add-to-cart to the product grid"
       activeKey="upload"
       conversations={[
         {
@@ -75,18 +88,25 @@ function AgentSession(props: { className?: string }) {
           lines: [
             {
               kind: "assistant",
-              text: "Done. Uploading a screenshot of the new checkout.",
+              text: "Done. Uploading a screenshot of the new grid.",
             },
             {
               kind: "tool",
-              text: "argos media upload checkout.png --branch feat/checkout",
+              text: "argos media upload sneakers-listing.png --branch feat/quick-add-to-cart",
             },
             {
               kind: "assistant",
               text: (
                 <>
                   No pull request yet, so it&apos;s staged on the branch:{" "}
-                  <Ref>app.argos-ci.com/m/kQ8vN2pX</Ref>
+                  <a
+                    href={LIVE_EXAMPLE_SHARE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-(--violet-11) underline decoration-(--violet-8) underline-offset-2 hover:decoration-(--violet-11)"
+                  >
+                    app.argos-ci.com/m/k2qshjz9b2…
+                  </a>
                 </>
               ),
             },
@@ -107,80 +127,96 @@ function AgentSession(props: { className?: string }) {
  * the media landed on GitHub — so the card is the pull request, and Argos'
  * comment sits inside it.
  *
- * The screenshot is rendered rather than listed, because the payoff is that a
- * reviewer *sees* the picture, not that a file was uploaded. One plain image,
- * and nothing beside it: a before/after pair reads as a baseline diff, which
- * is what the copy above says this is not, and an unrendered video row teaches
- * the opposite of the rendered screenshot it sits under. Both have their own
- * card further down the page.
+ * The comment is the real one, miniaturized: its bold "2 screenshots uploaded
+ * by Argos" first line, one before/after pair rendered as the row GitHub
+ * shows, and the second pair reduced to a file name — proof there are two
+ * without drawing two of everything. An earlier version rendered a single
+ * plain screenshot to avoid reading as a baseline diff, but the card now
+ * opens the actual pull request, and matching what the reader finds there is
+ * worth more than the abstraction; the "uploaded by Argos" header line is
+ * what keeps the pair reading as media rather than visual testing.
+ *
+ * The whole card is the link. The arrow next to the PR number is the only
+ * chrome admitting it — anything louder and the card stops reading as a pull
+ * request and starts reading as a button.
  */
 function PullRequestCard(props: { className?: string }) {
   return (
-    <Card
-      shadow="high"
-      className={clsx(
-        // A column all the way down, so the screenshot takes whatever height
-        // the agent session on the other side asks for. Growing the picture is
-        // the right way to spend that space: seeing it is the whole point.
-        "relative z-10 flex flex-col overflow-hidden",
-        "animate-fade-in-right animate-delay-250 animate-duration-500 fill-mode-both motion-reduce:animate-fade-in",
-        props.className,
-      )}
+    <a
+      href={LIVE_EXAMPLE_PR_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Open pull request snkr-shop#5 on GitHub"
+      className={clsx("group", props.className)}
     >
-      <div className="flex items-center gap-2 border-b-[0.5px] px-3 py-2">
-        <Chip variant="success" className="gap-1 text-xxs">
-          <GitPullRequestIcon className="size-2.5" />
-          Open
-        </Chip>
-        <SmallTitle className="min-w-0 truncate">Checkout redesign</SmallTitle>
-        <span className="ml-auto shrink-0 font-mono text-xxs text-low">
-          #482
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2 p-3">
-        <div className="flex items-center gap-2 text-xs">
-          <div className="grid size-5 shrink-0 place-items-center rounded border bg-(--plum-2)">
-            <ArgosEmblem className="size-2.5 w-auto" aria-hidden />
-          </div>
-          <span className="font-semibold">argos-ci</span>
-          <Chip className="text-xxs">bot</Chip>
-          <span className="truncate font-medium text-low">commented</span>
+      <Card
+        shadow="high"
+        className={clsx(
+          // A column all the way down, so the comment takes whatever height
+          // the agent session on the other side asks for. Growing the panes is
+          // the right way to spend that space: seeing them is the whole point.
+          "relative z-10 flex h-full flex-col overflow-hidden",
+          "transition group-hover:border-(--plum-8)",
+          "animate-fade-in-right animate-delay-250 animate-duration-500 fill-mode-both motion-reduce:animate-fade-in",
+        )}
+      >
+        <div className="flex items-center gap-2 border-b-[0.5px] px-3 py-2">
+          <Chip variant="success" className="gap-1 text-xxs">
+            <GitPullRequestIcon className="size-2.5" />
+            Open
+          </Chip>
+          <SmallTitle className="min-w-0 truncate">
+            Quick add-to-cart from the product grid
+          </SmallTitle>
+          <span className="ml-auto shrink-0 font-mono text-xxs text-low">
+            #5
+          </span>
+          <ArrowUpRightIcon className="size-3 shrink-0 text-low transition group-hover:text-(--plum-11)" />
         </div>
-        <div className="flex flex-1 flex-col overflow-hidden rounded border">
-          <ScreenshotPreview />
-          <div className="flex items-center gap-2 border-t-[0.5px] bg-app px-2.5 py-1.5">
-            <span className="min-w-0 truncate font-mono text-xxs">
-              checkout.png
-            </span>
+        <div className="flex flex-1 flex-col gap-2 p-3">
+          <div className="flex items-center gap-2 text-xs">
+            <div className="grid size-5 shrink-0 place-items-center rounded border bg-(--plum-2)">
+              <ArgosEmblem className="size-2.5 w-auto" aria-hidden />
+            </div>
+            <span className="font-semibold">argos-ci</span>
+            <Chip className="text-xxs">bot</Chip>
+            <span className="truncate font-medium text-low">commented</span>
+          </div>
+          <div className="flex flex-1 flex-col overflow-hidden rounded border">
+            <div className="px-2.5 pt-2 pb-1.5 text-xxs font-semibold">
+              2 screenshots uploaded by Argos
+            </div>
+            <div className="grid flex-1 grid-cols-2 divide-x-[0.5px] border-y-[0.5px] bg-subtle">
+              <Pane label="Before">
+                <Storefront variant="before" />
+              </Pane>
+              <Pane label="After">
+                <Storefront variant="after" />
+              </Pane>
+            </div>
+            <div className="flex items-center gap-2 bg-app px-2.5 py-1.5 font-mono text-xxs">
+              <span className="min-w-0 truncate">sneakers-listing.png</span>
+              <span className="ml-auto shrink-0 text-low max-sm:hidden">
+                + sneakers-detail.png
+              </span>
+              <span className="ml-auto shrink-0 text-low sm:hidden">
+                + 1 more
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </Card>
+      </Card>
+    </a>
   );
 }
 
-/**
- * A stand-in for the rendered screenshot. A flat gradient reads as a color
- * swatch; the skeleton is what makes it read as a captured interface — and it
- * is the page the agent just said it built, a single column with the summary
- * on top, so the picture and the conversation agree.
- *
- * The summary block is the one that grows, so the capture fills whatever
- * height the session on the other side asks for without opening a gap in the
- * middle. Marks are drawn in the foreground color at low opacity to hold up in
- * both themes; only the submit button is a solid brand color.
- */
-function ScreenshotPreview() {
+function Pane(props: { label: string; children: React.ReactNode }) {
   return (
-    <div
-      aria-hidden
-      className="flex min-h-24 flex-1 flex-col gap-1.5 bg-linear-to-br from-(--neutral-2) to-(--plum-3) p-2.5"
-    >
-      <span className="h-1.5 w-1/3 rounded-full bg-(--neutral-12)/25" />
-      <span className="min-h-5 flex-1 rounded-xs bg-(--neutral-12)/10" />
-      <span className="h-2 w-full rounded-xs bg-(--neutral-12)/10" />
-      <span className="h-2 w-full rounded-xs bg-(--neutral-12)/10" />
-      <span className="h-2.5 w-2/5 rounded-xs bg-(--plum-9)" />
+    <div className="flex flex-col gap-1.5 p-2">
+      <span className="text-xxxs font-medium tracking-wide text-low uppercase">
+        {props.label}
+      </span>
+      {props.children}
     </div>
   );
 }

--- a/app/media-sharing/features/MediaFlow.tsx
+++ b/app/media-sharing/features/MediaFlow.tsx
@@ -105,7 +105,7 @@ function AgentSession(props: { className?: string }) {
                     rel="noopener noreferrer"
                     className="text-(--violet-11) underline decoration-(--violet-8) underline-offset-2 hover:decoration-(--violet-11)"
                   >
-                    app.argos-ci.com/m/k2qshjz9b2…
+                    app.argos-ci.com/m/mp21qmkhpe…
                   </a>
                 </>
               ),

--- a/app/media-sharing/features/PinnedFeedback.tsx
+++ b/app/media-sharing/features/PinnedFeedback.tsx
@@ -19,11 +19,11 @@ import { Storefront } from "./Storefront";
  * because "0.62, 0.34" is the whole trick: a spot a blind process can act on.
  *
  * The image is the live example's sneaker grid, so the story stays in one
- * universe across the page. The pin and the thread are the one staged
- * element: the demo media has no open feedback, which is why this card's
- * live link is the share page, not proof of this exact thread. The CLI line
- * keeps the docs' numeric media id — the share slug in the page URL is not
- * what `media comment list` takes.
+ * universe across the page — and the demo media really does carry pinned,
+ * resolved feedback in its activity log. This exact thread (Nina's, open) is
+ * still staged, which is why the card's live link is the share page rather
+ * than proof of this thread. The CLI line keeps the docs' numeric media id —
+ * the share slug in the page URL is not what `media comment list` takes.
  */
 export function PinnedFeedback() {
   return (

--- a/app/media-sharing/features/PinnedFeedback.tsx
+++ b/app/media-sharing/features/PinnedFeedback.tsx
@@ -1,11 +1,12 @@
 import { CornerDownRightIcon, MessagesSquareIcon } from "lucide-react";
 
 import { ninaAvatar } from "@/app/assets/people/library";
-import { ApplicationSVG } from "@/components/ApplicationSVG";
 import { Badge } from "@/components/Badge";
 import { Card } from "@/components/Card";
 import { Chip } from "@/components/Chip";
 import { ThemeImage } from "@/components/ThemeImage";
+
+import { Storefront } from "./Storefront";
 
 /**
  * The loop that makes uploads more than fire-and-forget: a reviewer pins a
@@ -16,6 +17,13 @@ import { ThemeImage } from "@/components/ThemeImage";
  * with it, and the terminal line the agent answers through. The coordinates
  * appear twice on purpose — under the comment and nowhere else in prose —
  * because "0.62, 0.34" is the whole trick: a spot a blind process can act on.
+ *
+ * The image is the live example's sneaker grid, so the story stays in one
+ * universe across the page. The pin and the thread are the one staged
+ * element: the demo media has no open feedback, which is why this card's
+ * live link is the share page, not proof of this exact thread. The CLI line
+ * keeps the docs' numeric media id — the share slug in the page URL is not
+ * what `media comment list` takes.
  */
 export function PinnedFeedback() {
   return (
@@ -24,17 +32,21 @@ export function PinnedFeedback() {
       className="w-full max-w-md animate-slide-up-fade overflow-hidden animate-duration-500 fill-mode-both motion-reduce:animate-fade-in"
     >
       <div className="flex items-center gap-2 border-b-[0.5px] px-3 py-2">
-        <span className="font-mono text-xs font-medium">checkout.png</span>
-        <Badge className="ml-auto gap-1 text-xxs">
+        <span className="min-w-0 truncate font-mono text-xs font-medium">
+          sneakers-listing.png
+        </span>
+        <Badge className="ml-auto shrink-0 gap-1 text-xxs">
           <MessagesSquareIcon className="size-3" />1 open thread
         </Badge>
       </div>
       {/* Cropped rather than scaled: the card has to fit the h-72 slot of
-          FeatureGridFeature, and the story only needs the image's upper half —
-          the pin, and the words about it. */}
+          FeatureGridFeature, and the story only needs the grid's upper rows —
+          the pin, and the words about it. Three storefront rows fill the crop;
+          two would leave the card sitting in dead space. */}
       <div className="relative h-36 overflow-hidden bg-subtle px-3 pt-3">
-        <ApplicationSVG className="w-full" withChanges="success" />
-        {/* The pin, at the coordinates the comment quotes. */}
+        <Storefront variant="after" rows={3} className="w-full" />
+        {/* The pin, at the coordinates the comment quotes — over the second
+            row's add-to-cart button, the thing the comment complains about. */}
         <span className="absolute top-[34%] left-[58%]" aria-hidden>
           <span className="absolute inset-0 animate-ping rounded-full bg-(--plum-8) opacity-60" />
           <span className="relative grid size-4 place-items-center rounded-full border border-(--plum-8) bg-(--plum-9) text-xxxs font-semibold text-white shadow-xs">
@@ -52,7 +64,7 @@ export function PinnedFeedback() {
             <span className="text-xxxs text-low">pinned · 0.62, 0.34</span>
           </div>
           <p className="mt-1 text-xxs text-low">
-            The primary button is misaligned here.
+            Add to cart is misaligned on this card.
           </p>
         </div>
       </div>
@@ -61,7 +73,7 @@ export function PinnedFeedback() {
           <span aria-hidden className="shrink-0 text-(--plum-11)">
             $
           </span>
-          <span>argos media comment list 4821</span>
+          <span className="truncate">argos media comment list 4821</span>
         </div>
         <div className="flex items-center gap-1.5">
           <CornerDownRightIcon className="size-3 shrink-0 text-low" />

--- a/app/media-sharing/features/Storefront.tsx
+++ b/app/media-sharing/features/Storefront.tsx
@@ -1,0 +1,71 @@
+import clsx from "clsx";
+
+/**
+ * The SNKR.shop product grid from the live example, reduced to a skeleton: a
+ * storefront header and four columns of product cards on a white page. It
+ * exists so a pane that claims to show sneakers-listing.png rhymes with the
+ * real screenshot a visitor sees after clicking through to the share page.
+ *
+ * The two variants encode the actual change the pull request makes, not a
+ * generic "something changed" tint: `before` keeps the price at the bottom of
+ * the card next to an outline preview button, `after` moves the price up next
+ * to the name and gives every card a solid add-to-cart button. The button is
+ * the page's feature color rather than the shop's black, for the same reason
+ * every skeleton on this site paints the one meaningful mark in the accent.
+ */
+export function Storefront(props: {
+  variant: "before" | "after";
+  /**
+   * Two rows fit the compare panes; three fill the taller pinned-feedback
+   * crop, and match the real capture, which shows a third row of sneakers.
+   */
+  rows?: 2 | 3;
+  className?: string;
+}) {
+  const { variant, rows = 2, className } = props;
+  return (
+    <div
+      aria-hidden
+      className={clsx(
+        "flex flex-col gap-1.5 rounded-sm border-[0.5px] bg-app p-1.5 shadow-xs",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-1">
+        <span className="h-1 w-5 rounded-full bg-(--neutral-12)/25" />
+        <span className="ml-auto h-1 w-2.5 rounded-full bg-(--neutral-12)/10" />
+        <span className="h-1 w-2.5 rounded-full bg-(--neutral-12)/10" />
+      </div>
+      <div className="grid grid-cols-4 gap-1">
+        {Array.from({ length: rows * 4 }, (_, index) => (
+          <ProductCard key={index} variant={variant} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProductCard(props: { variant: "before" | "after" }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-xs border-[0.5px] p-1">
+      <span className="h-4 rounded-[1px] bg-(--neutral-12)/10" />
+      {props.variant === "before" ? (
+        <>
+          <span className="h-1 w-3/4 rounded-full bg-(--neutral-12)/25" />
+          <span className="flex items-center">
+            <span className="h-1.5 w-1/2 rounded-[2px] border-[0.5px]" />
+            <span className="ml-auto h-1 w-2 rounded-full bg-(--neutral-12)/25" />
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="flex items-center">
+            <span className="h-1 w-1/2 rounded-full bg-(--neutral-12)/25" />
+            <span className="ml-auto h-1 w-2 rounded-full bg-(--neutral-12)/25" />
+          </span>
+          <span className="h-1.5 w-full rounded-[2px] bg-(--plum-9)" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/media-sharing/live-example.ts
+++ b/app/media-sharing/live-example.ts
@@ -9,7 +9,7 @@
  * the MediaFlow card renders its "Open" state.
  */
 export const LIVE_EXAMPLE_SHARE_URL =
-  "https://app.argos-ci.com/m/k2qshjz9b2486gcpij9n";
+  "https://app.argos-ci.com/m/mp21qmkhpekfx1v4ot7r";
 
 export const LIVE_EXAMPLE_PR_URL =
   "https://github.com/argos-ci/snkr-shop/pull/5";

--- a/app/media-sharing/live-example.ts
+++ b/app/media-sharing/live-example.ts
@@ -1,0 +1,15 @@
+/**
+ * The live example this page's illustrations point at: a real pull request on
+ * the public snkr-shop demo repository, and the public share link of a
+ * before/after pair staged on its branch. The illustrations stylize this
+ * exact flow — same title, branch, and file names — so a visitor who clicks
+ * through lands on the thing the drawing promised.
+ *
+ * If the demo is ever redone, update both URLs together and keep the PR open:
+ * the MediaFlow card renders its "Open" state.
+ */
+export const LIVE_EXAMPLE_SHARE_URL =
+  "https://app.argos-ci.com/m/k2qshjz9b2486gcpij9n";
+
+export const LIVE_EXAMPLE_PR_URL =
+  "https://github.com/argos-ci/snkr-shop/pull/5";

--- a/app/media-sharing/page.tsx
+++ b/app/media-sharing/page.tsx
@@ -31,6 +31,7 @@ import {
   HeroDescription,
   HeroHeading,
 } from "@/components/Hero";
+import { Link as TextLink } from "@/components/Link";
 import { SectionHeader, SectionHeaderTexts } from "@/components/SectionHeader";
 import { Terminal } from "@/components/Terminal";
 import { SectionDescription, SectionTitle } from "@/components/Typography";
@@ -44,6 +45,7 @@ import { MediaFlow } from "./features/MediaFlow";
 import { MediaUploadTerminal } from "./features/MediaUploadTerminal";
 import { PinnedFeedback } from "./features/PinnedFeedback";
 import { VersionStack } from "./features/VersionStack";
+import { LIVE_EXAMPLE_PR_URL, LIVE_EXAMPLE_SHARE_URL } from "./live-example";
 
 export const metadata: Metadata = getMetadata({
   title: "Media Sharing",
@@ -57,6 +59,13 @@ const skillCode = `# Install the Argos skills for your coding agent
 npx skills add https://argos-ci.com`;
 
 const color = "plum" as const;
+
+// Every feature card points at the same live artifact on purpose: one real
+// thing to open, seen from four angles.
+const liveExample = {
+  href: LIVE_EXAMPLE_SHARE_URL,
+  label: "See it live",
+};
 
 export default function Page() {
   return (
@@ -113,6 +122,25 @@ export default function Page() {
           <div className="flex justify-center">
             <MediaFlow />
           </div>
+          <p className="mt-8 container-gutter text-center text-sm text-low">
+            This example is live —{" "}
+            <TextLink
+              href={LIVE_EXAMPLE_PR_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              see the pull request on GitHub
+            </TextLink>{" "}
+            or{" "}
+            <TextLink
+              href={LIVE_EXAMPLE_SHARE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              open the share link
+            </TextLink>
+            .
+          </p>
         </Container>
       </section>
       <section className="px-4">
@@ -130,6 +158,7 @@ export default function Page() {
             }
             href="/docs/learn/media/standalone-media-upload"
             illustration={<MediaUploadTerminal />}
+            example={liveExample}
           />
           <FeatureGridFeature
             title={<>Before and after, one link</>}
@@ -143,6 +172,7 @@ export default function Page() {
             }
             href="/docs/learn/media/standalone-media-upload#before-and-after-pairs"
             illustration={<BeforeAfterPair />}
+            example={liveExample}
           />
           <FeatureGridFeature
             title={<>Feedback pinned to the pixel</>}
@@ -156,6 +186,7 @@ export default function Page() {
             }
             href="/docs/learn/media/standalone-media-upload#reading-the-feedback-left-on-a-media"
             illustration={<PinnedFeedback />}
+            example={liveExample}
           />
           <FeatureGridFeature
             title={<>Re-upload freely, the link never changes</>}
@@ -169,6 +200,7 @@ export default function Page() {
             }
             href="/docs/learn/media/standalone-media-upload#versions-re-upload-same-link"
             illustration={<VersionStack />}
+            example={liveExample}
           />
         </FeatureGrid>
         <Container

--- a/components/AgentTerminal.tsx
+++ b/components/AgentTerminal.tsx
@@ -122,9 +122,11 @@ export function AgentTerminal(props: {
               aria-hidden={!isActive}
               // Applying the fade class as a step becomes active is what
               // replays it — the node is only ever given the class on the
-              // transition into view.
+              // transition into view. `min-w-0`, or the grid track sizes
+              // itself to the longest tool line and the whole cell slides out
+              // of the card instead of that one line truncating.
               className={clsx(
-                "col-start-1 row-start-1 space-y-2.5 pt-3 pb-6",
+                "col-start-1 row-start-1 min-w-0 space-y-2.5 pt-3 pb-6",
                 isActive
                   ? "animate-fade-in animate-duration-300 fill-mode-both"
                   : "invisible",
@@ -161,11 +163,13 @@ function Line(props: { line: TerminalLine }) {
     // Dimmed, and hung off the same edge as the prose: the agent reaching for
     // Argos, subordinate to the turn above it rather than a command the reader
     // is invited to run. The empty first cell matches the bullet's box, so the
-    // indent stays right without a magic number.
+    // indent stays right without a magic number. A command longer than the
+    // panel truncates rather than wraps — the real client does the same, and a
+    // command broken across lines stops reading as one call.
     return (
       <div className="flex gap-2 px-4">
         <span aria-hidden className="size-1.5 shrink-0" />
-        <span className="flex items-center gap-1.5 font-mono text-xxs text-low">
+        <span className="flex min-w-0 items-center gap-1.5 font-mono text-xxs text-low">
           {/* Drawn rather than typed. `⎿` is a box-drawing character, so its
               shape depends on whichever font resolves it — the same reason the
               answer bullet is a span and not a glyph. */}
@@ -173,7 +177,7 @@ function Line(props: { line: TerminalLine }) {
             aria-hidden
             className="mb-0.5 size-1.5 shrink-0 rounded-bl-[1px] border-b border-l border-(--neutral-8)"
           />
-          <span>{line.text}</span>
+          <span className="truncate">{line.text}</span>
         </span>
       </div>
     );

--- a/components/FeatureGrid.tsx
+++ b/components/FeatureGrid.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import type { LucideIcon } from "lucide-react";
+import { ArrowUpRightIcon, type LucideIcon } from "lucide-react";
 
 import { Button } from "./Button";
 import { Container } from "./Container";
@@ -32,8 +32,22 @@ export function FeatureGridFeature(props: {
   href: string;
   illustration: React.ReactNode;
   cta?: React.ReactNode;
+  /**
+   * A live artifact demonstrating the feature — a real share page, pull
+   * request, or build the illustration stylizes. Rendered as a second action
+   * beside the docs link, opening in a new tab so the reader keeps their
+   * place on the page.
+   */
+  example?: { href: string; label: React.ReactNode };
 }) {
-  const { title, description, href, illustration, cta = "Learn more" } = props;
+  const {
+    title,
+    description,
+    href,
+    illustration,
+    cta = "Learn more",
+    example,
+  } = props;
   return (
     <div className="relative flex flex-col gap-10 px-4 py-6 sm:px-6 sm:py-14">
       <div
@@ -45,9 +59,23 @@ export function FeatureGridFeature(props: {
       <div className="sm:px-4">
         <h3 className="mb-1 font-semibold">{title}</h3>
         <p className="font-[450] text-low">{description}</p>
-        <Button className="mt-4" variant="outline" asChild>
-          <Link href={href}>{cta}</Link>
-        </Button>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link href={href}>{cta}</Link>
+          </Button>
+          {example ? (
+            <Button variant="outline" asChild>
+              <Link
+                href={example.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ArrowUpRightIcon />
+                {example.label}
+              </Link>
+            </Button>
+          ) : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Visitors on `/media-sharing` can now see what media sharing actually looks like on a pull request and on the share page, instead of taking the illustrations' word for it. Every illustration links to a real, public artifact:

- **The pull request**: https://github.com/argos-ci/snkr-shop/pull/5
- **The share page** (opens on the before/after compare view): https://app.argos-ci.com/m/mp21qmkhpekfx1v4ot7r

## How

- **MediaFlow now tells the real story**: the agent session uploads `sneakers-listing.png` on `feat/quick-add-to-cart`, the printed share URL is a live link, and the PR card is snkr-shop#5 — title, `#5`, and the managed comment's bold **"2 screenshots uploaded by Argos"** line with its before/after row — the whole card opens the PR. A caption under the flow names both links explicitly.
- **Every feature card** gets a `See it live ↗` action beside `Learn more`, via a new optional `example` prop on `FeatureGridFeature`.
- **New `Storefront` skeleton** (shared by MediaFlow, BeforeAfterPair, PinnedFeedback) draws the SNKR.shop grid and encodes the PR's actual change: price moves up next to the name, every card gains a solid add-to-cart button.
- **Honesty boundary**: cards showing features the demo media doesn't currently exhibit (version history, the pinned thread) keep illustrative URLs and the docs' numeric media id, so the page never makes a claim about the real media that one click would disprove. BeforeAfterPair now says "Public link" instead of "Team only" for the same reason.
- **`AgentTerminal` fix**: `min-w-0` on the conversation grid cell — the long real command previously forced the grid track wider than the card and slid the whole cell out of it; now the tool line truncates like the real client.
- **Markdown twin** (`app/markdown/media-sharing.md`) mentions the live example so agents get the same pointers.

## Notes

- The PR card renders the "Open" state — snkr-shop#5 should stay open.
- Checked at 375px and desktop, light and dark, against the production build; `check-types`, `oxlint`, `oxfmt`, and `knip` are clean. Argos will show the visual diffs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
