### PR TITLE
Replace the terms of service and privacy policy

### DIFF
--- a/app/markdown/privacy.mdx
+++ b/app/markdown/privacy.mdx
@@ -62,15 +62,19 @@ Our website analytics is [Plausible](https://plausible.io), which is hosted in t
 
 We rely on the following providers to operate Argos. Each of them is bound by a written agreement, processes personal information only on our instructions, and is subject to confidentiality and security obligations consistent with our own.
 
-- **Amazon Web Services** — hosting, database, object storage, and content delivery. United States and European Union.
+- **Amazon Web Services** — hosting, database, and object storage, including the screenshots you upload. United States and European Union.
+- **ImageKit** — delivery and on-the-fly transformation of screenshots and other images served from files.argos-ci.com.
 - **Cloudflare** — DNS, content delivery, and caching. Global edge network.
+- **Redis** — queues, caching, and rate limiting supporting the processing of builds.
 - **Vercel** — hosting of the argos-ci.com website. United States.
 - **Stripe** — payment processing, subscriptions, and invoicing. United States and European Union.
 - **Resend** — delivery of transactional and notification email. United States.
 - **Sentry** — application error and performance monitoring. United States.
 - **Plausible Analytics** — website analytics. European Union.
 
-We update this list when our providers change. Customers who need advance notice of changes to this list can request it at [contact@argos-ci.com](mailto:contact@argos-ci.com).
+We also use standard business tools, including Google Workspace, Slack, and Linear, which may hold the contact details and the content of the messages you exchange with us.
+
+The authoritative and always-current list is published in our [trust center](https://app.eu.vanta.com/argos/trust/8z3w834xz9a4snga4obms/subprocessors), which prevails over the summary above. Customers who need advance notice of changes to it can request it at [contact@argos-ci.com](mailto:contact@argos-ci.com).
 
 **Integrations you connect.** Argos also exchanges data with GitHub, GitLab, Google, Slack, Discord, and Microsoft Teams when you choose to connect them, so that we can read repository metadata, post build statuses, and deliver notifications where your team works. Those providers act on their own behalf under their own terms and privacy policies, and the connection exists because you established it.
 

--- a/app/markdown/privacy.mdx
+++ b/app/markdown/privacy.mdx
@@ -2,7 +2,7 @@
 
 Last updated: August 12, 2026.
 
-Argos is a visual testing platform: it captures screenshots of your applications, compares them across builds, and lets your team review the visual changes. This policy explains what personal information we handle when you visit argos-ci.com, use Argos, or otherwise do business with us.
+Argos is a visual testing platform. Your test suite captures the screenshots and uploads them to Argos, which stores them, compares them across builds, and lets your team review the visual changes. Argos does not connect to your applications to produce those screenshots. This policy explains what personal information we handle when you visit argos-ci.com, use Argos, or otherwise do business with us.
 
 ## 1. Who we are
 
@@ -70,6 +70,7 @@ We rely on the following providers to operate Argos. Each of them is bound by a 
 - **Stripe** — payment processing, subscriptions, and invoicing. United States and European Union.
 - **Resend** — delivery of transactional and notification email. United States.
 - **Sentry** — application error and performance monitoring. United States.
+- **Bright Data** — reverse proxy providing a stable IP range, so that customers who restrict inbound traffic can allow-list connections coming from Argos.
 - **Plausible Analytics** — website analytics. European Union.
 
 We also use standard business tools, including Google Workspace, Slack, and Linear, which may hold the contact details and the content of the messages you exchange with us.

--- a/app/markdown/privacy.mdx
+++ b/app/markdown/privacy.mdx
@@ -1,92 +1,136 @@
-# Privacy
+# Privacy policy
 
-Last motifided: May 13th, 2017.
+Last updated: August 12, 2026.
 
-At Argos, we provide visual regression testing for your web apps, mobile apps and games, which gives developers the insight needed to quickly iterating on UIs.
+Argos is a visual testing platform: it captures screenshots of your applications, compares them across builds, and lets your team review the visual changes. This policy explains what personal information we handle when you visit argos-ci.com, use Argos, or otherwise do business with us.
 
-Argos is committed to protecting and respecting your privacy. This Privacy Policy sets out how we collect and process personal information about you when you visit our website argos-ci.com, when you use our products and services (our “Services”), or when you otherwise do business or make contact with us.
+## 1. Who we are
 
-Please read this policy carefully to understand how we handle and treat your personal information.
+Argos is operated by Smooth Code SAS, a company incorporated under the laws of France, registered with the Paris Trade and Companies Register under number 830 511 788, with its registered office at 30 Boulevard de Sébastopol, 75004 Paris, France.
 
-## What information do we collect?
+For the processing described in this policy where we act as a controller, Smooth Code SAS is the data controller. You can reach us at [contact@argos-ci.com](mailto:contact@argos-ci.com).
 
-We may collect and process the following personal information from you:
+## 2. The two roles we play
 
-- **Information you provide to us:** We collect personal information when you voluntarily provide us with such information in the course of using our website or Services. For example, when you register to use our Services, we will collect your name, email address and organization information. We also collect personal information from you when you subscribe to our newsletter, or respond to a survey. If you make an enquiry through our website, or contact us in any other way, we will keep a copy of your communications with us.
-- **Information we collect when you do business with us:** We may process your personal information when you do business with us – for example, as a customer or prospective customer, or as a vendor, supplier, consultant or other third party. For example, we may hold your business contact information and financial account information (if any) and other communications you have with us for the purposes of maintaining our business relations with you.
-- **Information we automatically collect:** We may also collect certain technical information by automatic means when you visit our website, such as IP address, browser type and operating system, referring URLs, your use of our website, and other clickstream data. We collect this information automatically through the use of various technologies, such as cookies.
-- **Personal information where we act as a data processor:** We also process personal information on behalf of our customers in the context of supporting our products and services. Where a customer subscribes to our Services for their website, game or app, they will be the ones who control what event data is collected and stored on our systems. For example, they may ask us to log basic user data (e.g. email address or username), device identifiers, IP addresses, event type, and related source code. In such cases, we are data processors acting in accordance with the instructions of our customers. You will need to refer to the privacy policies of our customers to find out more about how such information is handled by them.
+It matters which of the following applies, because it determines who decides what happens to the data.
 
-## What do we use your information for?
+**We are a controller** for the personal information we handle to run our own business: visitors to our website, people who create an Argos account, people who contact us, and people who work at our customers and prospects.
 
-The personal information we collect from you may be used in one of the following ways:
+**We are a processor** for the content our customers send into Argos. Screenshots, builds, test metadata, and other content uploaded by a customer are processed on that customer's instructions. If a screenshot of a customer's application contains personal information, the customer decides that, not us. Where you are an end user of an application tested with Argos, the relevant privacy policy is that of the customer operating that application, not this one.
 
-- To deal with your inquiries and requests
-- To create and administer records about any online account that you register with us
-- To provide you with information and access to resources that you have requested from us
-- To provide you with technical support (your information helps us to better respond to your individual needs)
-- To improve our website (we continually strive to improve our website offerings based on the information and feedback we receive from you), including to improve the navigation and content of our sites
-- For website and system administration and security
-- For general business purposes, including to improve customer service (your information helps us to more effectively respond to your customer service requests and support needs), to help us improve the content and functionality of our Services, to better understand our users, to protect against wrongdoing, to enforce our Terms of Service, and to generally manage our business
-- To process transactions and to provide Services to our customers and end-users
-- For recruitment purposes, where you apply for a job with us
-- To administer a contest, promotion, survey, or other site features
-- To send periodic emails. The email address you provide for order processing, will only be used to send you information and updates pertaining to your order. Where it is in accordance with your marketing preferences, we will send occasional marketing emails about our products and services, which you can unsubscribe from at any time using the link provided in the message.
+Our customers decide what their screenshots contain. We ask them not to send special categories of personal data, payment card data, or government identifiers into the Service unless separately agreed in writing.
 
-## How do we protect your information?
+## 3. Information we handle
 
-We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information. We offer the use of a secure server. All supplied sensitive/credit information is transmitted via Secure Socket Layer (SSL) technology and then encrypted into our Payment gateway providers database only to be accessible by those authorized with special access rights to such systems, and are required to keep the information confidential. After a transaction, your private information (credit cards, social security numbers, financials, etc.) will not be stored on our servers.
+**Account information.** Name, email address, profile picture, and the identity provider you signed in with. Argos accounts are created through GitHub, GitLab, or Google, or through your organization's single sign-on. We receive the profile information those providers make available for the scopes you approve. We never receive your password.
 
-## Do we use cookies?
+**Organization and team information.** Team names, member lists, roles and permissions, invitations, and email domains you configure for automatic joining.
 
-Yes. Cookies are small files that a site or its service provider transfers to your computers hard drive through your Web browser (if you allow) that enables the sites or service providers systems to recognize your browser and capture and remember certain information.
+**Project and repository information.** The repositories, projects, branches, pull requests, and builds you connect to Argos, and the metadata we need to attach a build to a commit.
 
-We use cookies to understand and save your preferences for future visits, to advertise to you on other sites and compile aggregate data about site traffic and site interaction so that we can offer better site experiences and tools in the future.
+**Customer Data.** Screenshots, images, videos, diffs, test names and metadata, review decisions, and comments submitted to the Service. We handle this as a processor, as described above.
 
-You may refuse to accept cookies by activating the setting on your browser which allows you to refuse the setting of cookies. You can find information on popular browsers and how to adjust your cookie preferences at the following websites:
+**Billing information.** Company name, billing address, VAT number, plan, usage counters, and invoice history. Card numbers are collected and stored by our payment provider, not by us.
 
-- [Microsoft Interne Explorer](https://www.microsoft.com/info/cookies.mspx)
-- [Mozilla Firefox](https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences)
-- [Google Chrome](https://support.google.com/accounts/answer/61416)
-- [Apple Safari](https://support.apple.com/en-us/HT201265)
+**Support and business communications.** The content of the messages you send us, and the contact details you use to send them.
 
-However, if you choose to disable cookies, you may be unable to access certain parts of our site. Unless you have adjusted your browser setting so that it will refuse cookies, our system will issue cookies when you log on to our site.
+**Technical information.** IP address, browser and operating system, pages viewed, timestamps, referring URL, and application error reports. We use this to operate the Service, investigate incidents, and prevent abuse.
 
-## Do we disclose any information to outside parties?
+## 4. Why we handle it, and on what legal basis
 
-We will only share your information with third parties in certain circumstances:
+- **To provide the Service** — creating and administering your account, running builds and comparisons, sending build results and review notifications, and providing support. Legal basis: performance of our contract with you.
+- **To bill you** — subscriptions, usage, overage, invoices, and dunning. Legal basis: performance of our contract, and compliance with our accounting obligations.
+- **To keep the Service secure and reliable** — authentication, rate limiting, abuse and fraud prevention, error monitoring, and incident investigation. Legal basis: our legitimate interest in protecting the Service and its users.
+- **To improve the Service** — understanding which features are used, and aggregated or anonymized analysis of usage. Legal basis: our legitimate interest in improving our product.
+- **To communicate with you** — service, security, and billing notices, and responses to your questions. Legal basis: performance of our contract and our legitimate interest in maintaining our business relationship.
+- **To send marketing** — occasional emails about Argos to business contacts. Legal basis: your consent where it is required, otherwise our legitimate interest in promoting our product to professional contacts. You can unsubscribe from any marketing email using the link it contains.
+- **To meet our legal obligations** — keeping accounting records and responding to lawful requests from authorities. Legal basis: compliance with a legal obligation.
 
-- We engage certain trusted third parties to perform functions and provide services to us, including cloud hosting services, off-site backups, email service providers, and customer support providers. We will only share your personal information with third parties to the extent necessary to perform these functions, in accordance with the purposes set out in this Privacy Policy and applicable laws.
-- In the event of a corporate sale, merger, reorganization, dissolution or similar event, your personal information may be sold, disposed of, transferred or otherwise disclosed as part of that transaction.
-- We may also disclose information about you to third parties where we believe it necessary or appropriate under law, for example: (1) to protect or defend our rights, interests or property or that of third parties; (2) to comply with legal process, judicial orders or subpoenas; (3) to respond to requests from public or government authorities, including for national security and law enforcement purposes; (4) to prevent or investigate possible wrongdoing in connection with the Services or to enforce our Terms of Service; (5) to protect the vital interests of our users, customers and other third parties.
-- We may use and share aggregated non-personal information with third parties for marketing, advertising and analytics purposes.
+## 5. We do not sell your information
 
-We do not sell or trade your personal information to third parties.
+We do not sell or rent personal information, and we do not share it with third parties for their own advertising purposes.
 
-## Third Party Links
+## 6. Cookies and analytics
 
-Occasionally, at our discretion, we may include or offer third party products or services on our website. If you access other websites using the links provided, the operators of these websites may collect information from you that will be used by them in accordance with their privacy policies. These third party sites have separate and independent privacy policies. We therefore have no responsibility or liability for the content and activities of these linked sites. Nonetheless, we seek to protect the integrity of our site and welcome any feedback about these sites.
+We use cookies that are strictly necessary to operate the Service: keeping you signed in and protecting the sign-in flow against request forgery.
 
-## International Transfers
+We do not use advertising cookies, and we do not use cookies to track you across other websites.
 
-If you are visiting our website or using our Services from outside the United States (US), please be aware that you are sending personal information to the US where our servers are located. The US may not have data protection laws that are as comprehensive or protective as those in your country of residence; however, our collection, storage and use of your personal information will at all times be in accordance with this Privacy Policy.
+Our website analytics is [Plausible](https://plausible.io), which is hosted in the European Union, sets no cookies, and does not build a profile of individual visitors or follow them across sites.
 
-## Your Rights
+## 7. Service providers and subprocessors
 
-If you are from the EU, you may have the right to access a copy of the personal information we hold about you, or to request the correction, amendment or deletion of such information where it is inaccurate or processed in violation of the Privacy Shield Principles. To make such a request, please contact us at the contact details at the left.
+We rely on the following providers to operate Argos. Each of them is bound by a written agreement, processes personal information only on our instructions, and is subject to confidentiality and security obligations consistent with our own.
 
-We will consider and respond to your request in accordance with the Privacy Shield Principles and applicable laws.
+- **Amazon Web Services** — hosting, database, object storage, and content delivery. United States and European Union.
+- **Cloudflare** — DNS, content delivery, and caching. Global edge network.
+- **Vercel** — hosting of the argos-ci.com website. United States.
+- **Stripe** — payment processing, subscriptions, and invoicing. United States and European Union.
+- **Resend** — delivery of transactional and notification email. United States.
+- **Sentry** — application error and performance monitoring. United States.
+- **Plausible Analytics** — website analytics. European Union.
 
-Furthermore, we commit to giving you an opportunity to opt-out if your personal information is to be disclosed to any other independent third parties, or to be used for a purpose materially different from those that are set out in this Privacy Policy. Where sensitive personal information is involved, we will always obtain your express opt-in consent to do such things. If you otherwise wish to limit the use or disclosure of your personal information, please write to us at the contact details further below.
+We update this list when our providers change. Customers who need advance notice of changes to this list can request it at [contact@argos-ci.com](mailto:contact@argos-ci.com).
 
-You can also unsubscribe from our marketing communications at any time by following the instructions or unsubscribe mechanism in the email message itself.
+**Integrations you connect.** Argos also exchanges data with GitHub, GitLab, Google, Slack, Discord, and Microsoft Teams when you choose to connect them, so that we can read repository metadata, post build statuses, and deliver notifications where your team works. Those providers act on their own behalf under their own terms and privacy policies, and the connection exists because you established it.
 
-## Data Retention
+**Other disclosures.** We may also disclose personal information to our professional advisers, to an acquirer in the context of a merger, reorganization, or sale of our business, or to authorities where we are legally required to do so or where it is necessary to protect our rights, our users, or the Service.
 
-We may retain your personal information as long as you continue to use the Services, have an account with us or for as long as is necessary to fulfil the purposes outlined in the policy. You can ask to close your account by contacting us at the details below and we will delete your personal information on request.
+## 8. Where your information is processed
 
-We may however retain personal information for an additional period as is permitted or required under applicable laws, for legal, tax or regulatory reasons, or for legitimate and lawful business purposes.
+We are established in France. Our infrastructure runs on Amazon Web Services in the United States and in the European Union, and some of our providers are established in the United States.
 
-## Changes to our Privacy Policy
+Where personal information is transferred outside the European Economic Area, we rely on a transfer mechanism recognized under Chapter V of the GDPR, such as the European Commission's standard contractual clauses, together with the additional safeguards required by the circumstances of the transfer.
 
-If we decide to change our privacy policy, we will post those changes on this page, and/or update the Privacy Policy modification date below.
+You can request more information about the transfer mechanism applicable to a given provider at [contact@argos-ci.com](mailto:contact@argos-ci.com).
+
+## 9. How long we keep it
+
+- **Account and organization information** — for as long as your account is active, then deleted within a reasonable period after the account is closed.
+- **Customer Data** — available for retrieval for thirty (30) days after termination of the account or subscription, then deleted, subject to backup expiry.
+- **Billing and accounting records** — ten (10) years, as required by French commercial and tax law.
+- **Support communications** — for as long as needed to handle the request and to keep a record of our business relationship.
+- **Technical logs and error reports** — for a limited period, no longer than necessary for security, debugging, and abuse prevention.
+
+Copies held in backups are removed as those backups expire in accordance with our standard retention processes.
+
+## 10. How we protect it
+
+We encrypt data in transit and at rest, restrict access to production systems to the people who need it, require strong authentication for that access, keep audit trails, monitor for errors and anomalies, and review our dependencies for known vulnerabilities.
+
+Argos is SOC 2 Type II compliant. Our [security page](/security) describes our controls in more detail, and our source code is open, so you can audit much of this yourself.
+
+No system is perfectly secure, but if a personal data breach affects your information we will notify you and, where required, the competent supervisory authority, without undue delay.
+
+You can report a security issue to us at [security@argos-ci.com](mailto:security@argos-ci.com).
+
+## 11. Your rights
+
+If you are in the European Economic Area or the United Kingdom, you have the right to access the personal information we hold about you, to have it corrected or erased, to restrict or object to its processing, to receive it in a portable format, and to withdraw consent where our processing is based on consent.
+
+To exercise any of these rights, write to [contact@argos-ci.com](mailto:contact@argos-ci.com). We will respond within one month, and we may ask you for information needed to confirm your identity.
+
+If the personal information concerns content a customer uploaded to Argos, we will forward your request to that customer, who decides how it is handled.
+
+You also have the right to lodge a complaint with a supervisory authority. Ours is the Commission Nationale de l'Informatique et des Libertés (CNIL), 3 Place de Fontenoy, TSA 80715, 75334 Paris Cedex 07, France, [cnil.fr](https://www.cnil.fr).
+
+## 12. Children
+
+Argos is a professional development tool. It is not directed at children, and we do not knowingly collect personal information from anyone under 16.
+
+## 13. Changes to this policy
+
+We may update this policy as our product and our providers change. We will post the updated version on this page and change the date above. Where a change materially affects how we handle personal information, we will give notice through the Service or by email before it takes effect.
+
+## 14. Contact
+
+For any question about this policy or about how we handle personal information:
+
+**Smooth Code SAS**  
+30 Boulevard de Sébastopol  
+75004 Paris  
+France
+
+**Email:** [contact@argos-ci.com](mailto:contact@argos-ci.com)
+
+See also our [terms of service](/terms).

--- a/app/markdown/terms.mdx
+++ b/app/markdown/terms.mdx
@@ -147,7 +147,7 @@ Additional information about how Argos processes personal information is availab
 
 ## 14. Data location
 
-Argos hosts the Service on infrastructure operated by Amazon Web Services, located in the United States and in the European Union.
+Argos hosts the Service primarily on infrastructure operated by Amazon Web Services, located in the United States and in the European Union. Other providers listed in the Argos privacy policy and trust center may process Customer Data in the course of delivering the Service.
 
 Where applicable law requires safeguards for international transfers of personal data, Argos will use a transfer mechanism recognized under that law.
 

--- a/app/markdown/terms.mdx
+++ b/app/markdown/terms.mdx
@@ -1,150 +1,378 @@
-# Terms
+# Terms of service
 
-Last motifided: May 13th, 2017.
+Last updated: August 12, 2026.
 
-## 1. Services
+These terms take effect immediately for new customers. For customers with an active paid subscription on August 12, 2026, they take effect on September 11, 2026.
 
-- 1.1 These Argos Terms of Service (these “Terms”) apply to the features and functions provided by Functional Software, Inc. (“Argos,” “our,” or “we”) via argos-ci.com (the “Site”) (collectively, the “Services”). By accessing or using the Site or the Services, you agree to be bound by these Terms. If you do not agree to these Terms, you are not allowed to use the Site or the Services. The “Effective Date” of these Terms is the date you first use the Site, or access any of the Services.
+These Terms of Service (“Terms”) govern access to and use of the Argos software as a service platform, websites, applications, APIs, and related services made available by Smooth Code SAS (“Argos”, “we”, “us”, or “our”).
 
-- 1.2 If you are using the Site or accessing the Services in your capacity as an employee, consultant or agent of a company or other entity, you represent that you are an employee, consultant or agent of that company or entity, and that you have the authority to bind that company or entity to these Terms. For the purpose of these Terms, you (and, if applicable, the company or entity that you represent) will be referred to as “Customer” or “you”.
+Smooth Code SAS is a company incorporated under the laws of France, registered with the Paris Trade and Companies Register under number 830 511 788, with its registered office at 30 Boulevard de Sébastopol, 75004 Paris, France.
 
-- 1.3 Argos reserves the right to change or modify these Terms, or any of our other policies or guidelines, at any time upon notice to you. We may provide that notice in a variety of ways, including, without limitation, sending you an email, posting a notice on the Site, or posting the revised Terms on the Site and revising the date at the top of these Terms. Any changes or modifications will be effective after we provide notice that these Terms have been modified. You acknowledge that your continued use of the Site or any of the Services following such notice constitutes your acceptance of the modified Terms.
+By accessing or using Argos, you agree to these Terms.
 
-- 1.4 Argos reserves the right – at any time, and without notice or liability to you – to modify the Site or the Services, or any part of them, temporarily or permanently. We may modify the Services for a variety of reasons, including, without limitation, for the purpose of providing new features, implementing new protocols, maintaining compatibility with emerging standards, or complying with regulatory requirements.
+If you access or use Argos on behalf of a company or other organization, you represent that you have authority to bind that organization to these Terms. In that case, “Customer” or “you” refers to that organization.
 
-- 1.5 These Terms form a binding agreement between you and Argos. Violation of any of the Terms below will result in the termination of your account(s).
+## 1. Enterprise agreements
 
-## 2. Privacy
+Certain customers use Argos under a separately executed Master Services Agreement, Statement of Work, Order Form, or other written agreement with Smooth Code SAS.
 
-Please see Argos’ privacy policy at [https://argos-ci.com/privacy](https://argos-ci.com/privacy) for information about how we collect, use, and disclose information about users of the Site and the Services. By using the Site and the Services, you consent to our collection, use, and disclosure of information as set forth in our privacy policy, as we may update that policy from time to time.
+Where such an agreement exists, that agreement governs the applicable Services and prevails over these Terms to the extent of any conflict.
 
-## 3. Registration
+## 2. The Service
 
-- 3.1 In order to use many aspects of the Services, you must first complete the Argos registration process via the Site. During the registration process, you will be asked to select a package to access the Services (each, a “Plan”), which includes: (a) the period during which you can access the Services (the “Subscription Period”); and (b) the fee you must pay to Argos in exchange for your right to access the Services (the “Subscription Fees”). All such information is incorporated into these Terms by reference. We have several different types of paid Plans, as well as a free Plan, for which there are no Subscription Fees. One person or legal entity may not sign up for more than one free Plan.
+Argos provides software and related services for visual testing, visual review, and associated development workflows.
 
-- 3.2 You agree: (a) to provide accurate, current and complete information about you as part of the registration process (“Registration Data”); (b) to maintain the security of your password(s); (c) to maintain and promptly update your Registration Data, and any other information you provide to Argos, and to keep it accurate, current and complete; (d) to accept all risks of unauthorized access to your Registration Data, and any other information you provide to Argos, via your account(s) or password(s); (e) that you are responsible for maintaining the security of your account and safeguarding your password(s), and (f) that you will be fully responsible for any activities or transactions that take place using your account(s) or password(s), even if you were not aware of them.
+Subject to these Terms and payment of any applicable fees, Argos grants Customer a non-exclusive, non-transferable right to access and use the Service for its internal business purposes.
 
-## 4. Access to services
+We may modify and improve the Service over time, including by adding, changing, or removing features. Section 27 describes the commitments that apply to those changes.
 
-Subject to your continued compliance with these Terms, Argos grants you a limited, non-transferable, non-exclusive, revocable right and license to: (i) access and use the Services and its associated documentation, solely for your own internal business purposes, for the Subscription Period for which you have paid the applicable Subscription Fees; and (ii) access and use any data or reports that we provide or make available to you as part of your access and use of the Services (collectively, “Reports”), solely in conjunction with your use of the Services. Reports are considered part of the applicable Services, for the purpose of the license granted above. You understand that Argos uses third-party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to provide the Services, and you agree that Argos is not and will not be liable or responsible for the acts or omissions of such third-party vendors or hosting partners.
+## 3. Professional use
 
-## 5. Restrictions
+The Service is offered to businesses, organizations, and professionals for their internal business purposes.
 
-Except as expressly authorized by these Terms, you may not: (a) modify, disclose, alter, translate or create derivative works of the Site or the Services; (b) license, sublicense, resell, distribute, lease, rent, lend, transfer, assign or otherwise dispose of the Services or any Report (or any components thereof); (c) offer any part of the Services (including, without limitation, any Report) on a timeshare or service bureau basis; (c) allow or permit any third party to access or use the Services; (d) use the Site or the Services to store or transmit any viruses, software routines, or other code designed to permit anyone to access in an unauthorized manner, disable, erase or otherwise harm software, hardware, or data, or to perform any other harmful actions; (e) build a competitive product or service, or copy any features or functions of the Site or the Services (including, without limitation, the look-and-feel of the Site or the Services); (f) interfere with or disrupt the integrity or performance of the Site or the Services; (g) disclose to any third party any performance information or analysis relating to the Site or the Services; (h) remove, alter or obscure any proprietary notices in or on the Site or the Services, including copyright notices; (i) use the Site or the Services or any product thereof for any illegal or unauthorized purpose, or in a manner which violates any laws or regulations in your jurisdiction; (j) reverse engineer, decompile, disassemble, or otherwise attempt to discover the source code, object code, or underlying structure, ideas, or algorithms that make up the Services or any software, documentation, or data relating to the Services, except to the limited extent that applicable law prohibits such a restriction; or (k) cause or permit any third party to do any of the foregoing.
+The Service is not offered to consumers acting outside of a professional activity, and Customer represents that it accesses and uses the Service in a professional capacity.
 
-## 6. Content
+## 4. Accounts
 
-- 6.1 If you publish or upload data, images, code or content, or otherwise make (or allow any third party to make) material available by means of the Site or the Services (collectively, “Content”), you agree that you are entirely responsible for such Content, and for any harm or liability resulting from or arising out of that Content. Your responsibility applies whether or not the Content in question constitutes text, graphics, audio files, video files, computer software, or any other type of content, and whether or not you were the original creator or owner of the Content. You agree that you will be responsible for all Content on your account(s), even if placed there by third parties. By publishing or uploading Content to the Site or the Services, you represent and warrant that:
-  - a. the Content does not and will not infringe, violate or misappropriate the Intellectual Property Rights of any third party (where “Intellectual Property Rights” are defined as any patents, copyrights, moral rights, trademarks, trade secrets, or any other form of intellectual property rights recognized in any jurisdiction in the world, including applications and registrations for any of the foregoing);
+You are responsible for maintaining the security of your account and authentication credentials.
 
-  - b. you have obtained all rights and permissions necessary to publish and/or use the Content in the manner in which you have published and/or used it;
+You are responsible for activity performed through your account and for ensuring that users you authorize to access the Service comply with these Terms.
 
-  - c. Argos’s use of the Content for the purpose of providing the Services (including, without limitation, downloading, copying, processing, or creating aggregations of the Content) does not and will not (i) violate any applicable laws or regulations, or (ii) infringe, violate, or misappropriate the Intellectual Property Rights of any third party;
+You must promptly notify us if you become aware of unauthorized access to your account.
 
-  - d. you have fully complied with any third-party licenses relating to the Content;
+## 5. Free plans and trials
 
-  - e. the Content does not contain or install any viruses, worms, malware, Trojan horses or other harmful or destructive code;
+Argos may offer free plans or trial periods.
 
-  - f. the Content does not and will not include any: (i) “personal health information,” as defined under the Health Insurance Portability and Accountability Act, unless you have entered into a separate agreement with us relating to the processing of such data; (ii) government issued identification numbers, including Social Security numbers, drivers’ license numbers or other state-issued identification numbers; (iii) financial account information, including bank account numbers; (iv) payment card data, including credit card or debit card numbers; or (iv) “sensitive” personal data, as defined under Directive 95/46/EC of the European Parliament (“EU Directive”) and any national laws adopted pursuant to the EU Directive, about residents of Switzerland and any member country of the European Union, including racial or ethnic origin, political opinions, religious beliefs, trade union membership, physical or mental health or condition, sexual life, or the commission or alleged commission any crime or offense;
+Free plans and trials may be subject to usage limits, feature restrictions, or other limitations determined by Argos.
 
-  - g. the Content is not spam, is not randomly-generated, and does not contain unethical or unwanted commercial content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or for any other unlawful acts (such as phishing), or for misleading recipients as to the source of the material (such as spoofing);
+We may modify or discontinue free plans at any time.
 
-  - h. the Content does not contain threats or incitement to violence, and does not violate the privacy or publicity rights of any third party;
+Unless otherwise specified when a trial begins, a trial does not create a commitment to purchase a paid subscription.
 
-  - i. the Content is not being advertised via unwanted electronic messages (such as, by way of example, spam links on newsgroups, email lists, other blogs and web sites, and similar unsolicited promotional methods);
+If a trial requires a payment method and indicates that it will convert to a paid subscription at the end of the trial, the subscription will automatically begin unless canceled before the end of the trial.
 
-  - j. the Content is not named in a manner that misleads (or could mislead) third parties into thinking that you are another person or company (by way of example, your Content’s URL or name should not be confusingly similar to the name of another person or entity); and
+## 6. Paid subscriptions
 
-  - k. you have, in the case of Content that includes computer code, accurately categorized and/or described the type, nature, uses and effects of the materials, whether requested to do so by the Services or otherwise.
+Paid self service subscriptions are billed according to the pricing and billing period displayed when the subscription is purchased.
 
-- 6.2 By submitting or uploading Content to the Services, you grant Argos a worldwide, royalty-free, and non-exclusive license (i) to use, reproduce, modify, adapt and publish that Content solely for the purpose of providing the Services to you; and (ii) to create aggregations and summaries of the Content or portions thereof and to use, disclose, and distribute such aggregations publicly to any third party in support of our business (both during the period that these Terms are in effect, and thereafter), provided that such aggregations and summaries do not directly or indirectly identify you or your Content. If you delete Content, Argos will use reasonable efforts to remove it from the Services. You acknowledge, however, that cached copies or other references to the Content may still be available.
+Unless otherwise stated at the time of purchase, paid self service subscriptions automatically renew at the end of each billing period until canceled. Monthly subscriptions renew monthly, and annual subscriptions renew annually.
 
-- 6.3 Without limiting any of your representations or warranties with respect to the Content, Argos has the right (but not the obligation) to reject or remove any Content, without liability or notice to you, that Argos believes, in Argos’ sole discretion: (i) violates these Terms or any Argos policy, (ii) violates or misappropriates the Intellectual Property Rights of any third party, or (iii) is in any way harmful or objectionable.
+You may cancel your subscription at any time through the Service or by contacting Argos.
 
-## 7. Fee and payment terms; Plan upgrade/downgrade/cancellation; Pricing changes
+Cancellation takes effect at the end of the current paid billing period. You will retain access to the paid Service until that date.
 
-- 7.1 In exchange for your rights to access the Site and use the Services during the Subscription Period, you agree to pay the applicable Subscription Fees to Argos. The Subscription Fees do not include taxes; you will be responsible for, and will promptly pay, all taxes associated with your use of the Site and the Services, other than taxes based on our net income. Subscription Fees are payable in full, in advance, in accordance with your Plan, and are non-refundable and non-creditable. You agree to make all payments in U.S. Dollars.
+Except where required by law, expressly agreed otherwise, or provided under Section 28, payments are non-refundable and no credits or refunds are provided for partially used billing periods.
 
-- 7.2 You can cancel your account(s)/subscription(s) via the process set forth in the “Cancel Subscription” section of your Account Settings on the Site. An email or phone request to cancel your account is not considered cancellation. No refunds will be issued, unless expressly stated otherwise. All of your Content will be deleted from the Services within a reasonable time period from when you cancel your account/subscription. Deleted Content cannot be recovered once your account/subscription is cancelled.
+## 7. Usage and overage fees
 
-- 7.3 If you upgrade from the free Plan to any paid Plan, we will immediately bill you for the applicable Subscription Fees. There will be no refunds or credits for partial months of service, upgrade/downgrade refunds, or refunds for months unused with an open account.
+Certain plans include usage allowances.
 
-- 7.4 Downgrading your account(s) may cause the loss of Content, features, or capacity of your account(s). We do not accept any liability for such loss.
+If Customer exceeds the usage included in its plan, additional usage may be billed at the rates displayed on the applicable pricing page or agreed at the time of purchase.
 
-- 7.5 Each Subscription Period will automatically renew (and we may automatically invoice you) for additional Subscription Periods of equivalent length, unless and until one party provides written notice to the other at least thirty (30) days prior to the expiration of the then-current Subscription Period that it wishes to terminate the subscription at the end of the then-current Subscription Period. We reserve the right to modify the fees for the Services at any time upon thirty (30) days’ prior notice to you, provided that the modified fees will not apply until the next Subscription Period.
+Usage is measured by Argos based on records generated by the Service. Those records are authoritative absent manifest error.
 
-- 7.6 Interest on any late payments will accrue at the rate of 1.5% per month, or the highest rate permitted by law, whichever is lower, from the date the amount is due until the date the amount is paid in full. If you are late in paying us, you also agree that, in addition to our rights to suspend your access to the Services, terminate your account(s), downgrade you to a free Plan, and/or pursue any other rights or remedies available to us at law or in equity, you are responsible to reimburse us for any costs that we incur while attempting to collect such late payments.
+Argos may apply reasonable technical limits to prevent abuse or unusually excessive usage that threatens the operation or security of the Service.
 
-## 8. DISCLAIMER
+## 8. Fees, taxes, and late payment
 
-YOU ACKNOWLEDGE THAT THE SITE AND THE SERVICES ARE PROVIDED ON AN “AS IS”, “AS AVAILABLE” BASIS, WITHOUT WARRANTY OF ANY KIND, WHETHER EXPRESS OR IMPLIED, AND THAT YOUR USE OF THE SITE AND THE SERVICES IS AT YOUR SOLE RISK. ARGOS DOES NOT WARRANT: (I) THAT THE SITE OR THE SERVICES WILL MEET YOUR SPECIFIC REQUIREMENTS, (II) THAT THE SITE OR THE SERVICES WILL BE UNINTERRUPTED, TIMELY, SECURE, OR ERROR-FREE, (III) THAT THE RESULTS THAT MAY BE OBTAINED FROM THE USE OF THE SERVICES WILL BE ACCURATE OR RELIABLE, (IV) THAT THE QUALITY OF ANY PRODUCTS, SERVICES, INFORMATION, OR OTHER MATERIAL THAT YOU PURCHASE OR OBTAIN THROUGH THE SITE OR THE SERVICES WILL MEET YOUR EXPECTATIONS, OR (V) THAT ANY ERRORS IN THE SITE OR THE SERVICES WILL BE CORRECTED. ARGOS SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+Customer agrees to pay all applicable fees associated with its subscription.
 
-## 9. Indemnification obligations
+Prices are exclusive of taxes unless expressly stated otherwise.
 
-You agree, at your sole expense, to defend, indemnify and hold Argos (and its directors, officers, employees, consultants and agents) harmless from and against any and all actual or threatened suits, actions, proceedings (whether at law or in equity), claims, damages, payments, deficiencies, fines, judgments, settlements, liabilities, losses, costs and expenses (including, without limitation, reasonable attorneys’ fees, costs, penalties, interest and disbursements) arising out of or relating to (i) your Content; (ii) your use of the Site or the Services; (iii) your failure to pay any taxes that you owe under these Terms; and (iv) any other actual or alleged breach of any of your obligations under these Terms (including, among other things, any actual or alleged breach of any of your representations or warranties as set forth herein). You will not settle any such claim in any manner that would require Argos to pay money or admit wrongdoing of any kind without our prior written consent, which we may withhold in our sole discretion.
+Customer is responsible for applicable sales, use, value added, withholding, or similar taxes, except taxes imposed on the income of Smooth Code SAS.
 
-## 10. LIMITATION OF LIABILITY
+Any undisputed amount that remains unpaid after its due date accrues interest, without the need for a reminder, at the European Central Bank main refinancing rate in force plus ten percentage points, together with the fixed indemnity for recovery costs of forty (40) euros required by article L441-10 of the French Commercial Code and any reasonable collection costs actually incurred.
 
-- 10.1 IN NO EVENT WILL ARGOS’S TOTAL, AGGREGATE LIABILITY TO YOU OR TO ANY THIRD PARTY ARISING OUT OF OR RELATED TO THESE TERMS OR YOUR USE OF (OR INABILITY TO USE) ANY PART OF THE SITE OR THE SERVICES EXCEED THE TOTAL AMOUNT YOU ACTUALLY PAID TO ARGOS IN SUBSCRIPTION FEES FOR THE SERVICES DURING THE TWELVE (12) MONTHS IMMEDIATELY PRIOR TO THE ACCRUAL OF THE FIRST CLAIM. MULTIPLE CLAIMS WILL NOT EXPAND THIS LIMITATION.
+If payment cannot be collected when due, Argos may retry payment, restrict access to paid features, suspend the account, or terminate the applicable subscription after reasonable notice.
 
-- 10.2 IN NO EVENT WILL ARGOS BE LIABLE TO YOU OR TO ANY THIRD PARTY FOR ANY LOSS OF PROFITS, LOSS OF USE, LOSS OF REVENUE, LOSS OF GOODWILL, INTERRUPTION OF BUSINESS, LOSS OF DATA, OR ANY INDIRECT, SPECIAL, INCIDENTAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING OUT OF, OR IN CONNECTION WITH THESE TERMS OR YOUR USE (OR INABILITY TO USE) ANY PART OF THE SITE OR THE SERVICES, WHETHER IN CONTRACT, TORT, STRICT LIABILITY OR OTHERWISE, EVEN IF WE HAVE BEEN ADVISED OR ARE OTHERWISE AWARE OF THE POSSIBILITY OF SUCH DAMAGES.
+## 9. Customer Data
 
-- 10.3 THIS SECTION (LIMITATION OF LIABILITY) WILL BE GIVEN FULL EFFECT EVEN IF ANY REMEDY SPECIFIED IN THESE TERMS IS DEEMED TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+“Customer Data” means data, images, screenshots, files, configuration, metadata, or other information submitted by or on behalf of Customer to the Service.
 
-## 11. Ownership; Reservation of rights
+Customer retains all rights, title, and interest in Customer Data.
 
-- 11.1 As between the parties: (i) you own all right, title and interest in and to your Content; and (ii) Argos owns all right, title and interest in and to the Site and the Services, and all Intellectual Property Rights therein. The look and feel of the Site and the Services, including any custom graphics, button icons, and scripts are also the property of Argos, and you may not copy, imitate, or use them, in whole or in part, without Argos’ prior written consent. Argos reserves all rights not expressly granted to you in these Terms, and Argos does not grant any licenses to you or to any other party under these Terms, whether by implication, estoppel or otherwise, except as expressly set forth herein.
+Customer grants Argos a limited right to host, copy, transmit, process, display, and otherwise use Customer Data only as reasonably necessary to provide, maintain, secure, support, and improve the Service.
 
-- 11.2 You acknowledge that any suggestions, comments, or other feedback that you provide to Argos with respect to the Site, the Services, or any other Argos product or service (collectively, “Feedback”) will be owned by Argos, including all Intellectual Property Rights therein, and will be and become Argos’ Confidential Information (as defined below). You acknowledge and agree that Argos will be free to use, disclose, reproduce, license, and otherwise distribute and exploit the Feedback as Argos sees fit, without obligation or restriction of any kind. At our request and expense, you agree to execute documents or take such further actions as we may reasonably request to help us acquire, perfect, and maintain our rights in the Feedback.
+Customer is responsible for ensuring that it has the rights and permissions necessary to submit Customer Data to the Service and to permit its processing as described in these Terms.
 
-## 12 Term, termination, and effect of termination
+Argos does not acquire ownership of Customer Data.
 
-- 12.1 These Terms will apply to you starting on the Effective Date, and will continue for as long as you are accessing or using the Site or the Services.
+## 10. Aggregated and anonymous data
 
-- 12.2 Argos, in its sole discretion, has the right to suspend your ability to access the Services, without liability, under the following circumstances: (i) for scheduled or emergency maintenance to the Site or the Services, or any part thereof; (ii) if Argos believes that you are using the Site or Services in violation of these Terms or applicable law; (iii) if Argos believes that your use of the Site or the Services poses a security risk to us or to any third party; (iv) if required by law enforcement or government agency, or otherwise in order to comply with applicable law or regulation; or (v) if you fail to fulfill your payment obligations hereunder. Argos also reserves the right to temporarily or permanently suspend your ability to access the Services, without liability, if Argos determines, in its sole discretion, that you are engaging in abusive or excessively frequent use of the Services.
+Argos may generate and use statistical, aggregated, or anonymized information derived from use of the Service, provided that such information does not identify Customer or any individual.
 
-- 12.3 Either of us can terminate these Terms upon notice to the other if the other party breaches any of these Terms and fails to cure the breach within fifteen (15) days of receiving written notice of it from the non-breaching party. We reserve the right to terminate these Terms for cause immediately upon notice to you, and without giving you a cure period, if you breach any of these Terms relating to our intellectual property (including your compliance with the access grant and any restrictions) or our Confidential Information (defined below).
+Such information may be used to operate, analyze, secure, and improve Argos and to understand usage of the Service.
 
-- 12.4 We can terminate any free Plan that you have subscribed to, at any time and for any reason, without notice or liability to you. We can terminate any paid Plan that you have subscribed to, for any reason and without liability, by providing notice to you that we intend to terminate your Plan at the end of the then-current Subscription Period.
+## 11. Artificial intelligence
 
-- 12.5 When these Terms terminate or expire: (i) you will no longer have the right to use or access the Site or the Services as of the date of termination/expiration; (ii) if you owed us any fees prior to such termination/expiration, you will pay those fees immediately; and (iii) each of us will promptly return to the other (or, if the other party requests it, destroy) all Confidential Information belonging to the other. Sections 1, 2, 4 through 10, 11, and 13 through 15 will survive the termination or expiration of these Terms for any reason.
+Argos will not use Customer Data to train or fine-tune artificial intelligence or machine learning models without Customer's prior consent.
 
-## 13. Support
+This restriction does not prevent Argos from processing Customer Data as necessary to provide the Service, or from providing optional functionality that Customer expressly initiates or enables. Where such functionality relies on a third-party model provider, Argos will contract for the Customer Data submitted to that provider not to be used to train its models.
 
-- 13.1 If you are subscribed to a paid Plan, Argos will provide you with email-based support – just write to our support desk at [contact@smooth-code.com](mailto:contact@smooth-code.com). While we work hard to respond to you and resolve your issues quickly, we do not warrant that we will respond within any particular timeframe, or that we will be able to resolve your issue. If you are subscribed to a free Plan, while you are welcome to email us your questions, we encourage you to visit our community forum which can provide valuable information to help answer your questions.
+## 12. Confidentiality
 
-## 14. Confidential information
+“Confidential Information” means non-public information disclosed by one party to the other that is designated as confidential or that should reasonably be understood to be confidential given the nature of the information and the circumstances of disclosure.
 
-- 14.1 For the purposes of these Terms, “Confidential Information” means any technical or business information disclosed by one party to the other that: (i) if disclosed in writing, is marked “confidential” or “proprietary” at the time of disclosure; (ii) if disclosed orally, is identified as confidential or proprietary at the time of such disclosure, and is summarized in a writing sent by the disclosing Party to the receiving Party within thirty (30) days of the disclosure. For the purposes of these Terms you agree that the Feedback, any Reports we provide to you, and any non-public elements of the Site or the Services (including, without limitation, the source code of any Argos-proprietary software), will be deemed to be Argos’s Confidential Information, regardless of whether it is marked as such.
+Each party shall protect the other party's Confidential Information using reasonable care and shall use it only for purposes related to these Terms and the provision or use of the Service.
 
-- 14.2 Neither of us will use the other party’s Confidential Information, except as permitted by these Terms. Each of us agrees to maintain in confidence and protect the other party’s Confidential Information using at least the same degree of care as it uses for its own information of a similar nature, but in all events at least a reasonable degree of care. Each of us agrees to take all reasonable precautions to prevent any unauthorized disclosure of the other party’s Confidential Information, including, without limitation, disclosing Confidential Information only to its employees, independent contractors, consultants, and legal and financial advisors (collectively, “Representatives”): (i) with a need to know such information, (ii) who are parties to appropriate agreements sufficient to comply with this Section 13, and (iii) who are informed of the nondisclosure obligations imposed by this Section 13. Each party will be responsible for all acts and omissions of its Representatives. The foregoing obligations will not restrict either party from disclosing Confidential Information of the other party pursuant to the order or requirement of a court, administrative agency, or other governmental body, provided that the party required to make such a disclosure gives reasonable notice to the other party to enable them to contest such order or requirement.
+A receiving party may disclose Confidential Information to its employees, contractors, professional advisers, and service providers who need access to the information and who are subject to appropriate confidentiality obligations.
 
-- 14.3 The restrictions set forth in Section 13 will not apply with respect to any Confidential Information that: (i) was or becomes publicly known through no fault of the receiving party; (ii) was rightfully known or becomes rightfully known to the receiving party without confidential or proprietary restriction from a source other than the disclosing party who has a right to disclose it; (iii) is approved by the disclosing party for disclosure without restriction in a written document which is signed by a duly authorized officer of such disclosing party; or (iv) the receiving party independently develops without access to or use of the other party’s Confidential Information.
+Confidential Information does not include information that the receiving party can demonstrate:
 
-## 15. Trademarks
+- was lawfully known without restriction before disclosure
+- becomes publicly available without breach of these Terms
+- is received lawfully from a third party without confidentiality obligations
+- is independently developed without use of the other party's Confidential Information
 
-You acknowledge and agree that any Argos names, trademarks, service marks, logos, trade dress, or other branding included on the Site or as part of the Services (collectively, the “Marks”) are owned by Argos and may not be copied, imitated, or used (in whole or in part) without Argos’s prior written consent. All other trademarks, names, or logos referenced on the Site or the Services (collectively, “Third-Party Trademarks”) are the property of their respective owners, and the use of such Third-Party Trademarks inure to the benefit of their respective owners. The use of such Third-Party Trademarks is intended to denote interoperability, and does not constitute an affiliation by Argos or its licensors with any company or an endorsement or approval by that company of Argos, its licensors, or their respective products or services.
+A party may disclose Confidential Information where required by law, provided that it gives reasonable notice where legally permitted.
 
-## 16. General provisions
+These confidentiality obligations survive termination for five (5) years.
 
-- 16.1 These Terms, together with any policies incorporated into these Terms by reference, are the complete and exclusive understanding of the parties with respect to Argos’s provision of, and your use of and access to, the Site and the Services, and supersede all previous or contemporaneous agreements or communications, whether written or oral, relating to the subject matter of these Terms (including, without limitation, prior versions of these Terms). Any terms or conditions that you send to Argos that are inconsistent with or in addition to these Terms are hereby rejected by Argos, and will be deemed void and of no effect.
+## 13. Data protection and security
 
-- 16.2 These Terms will be governed by and construed in accordance with the laws of the State of California, without regard to that State’s conflict of law principles. Any legal action or proceeding arising under, related to or connected with these Terms will be brought exclusively in the federal (if they have jurisdiction) or state courts located in San Francisco, California, and the parties irrevocably consent to the personal jurisdiction and venue of such court(s). The United Nations Convention on Contracts for the International Sale of Goods and the Uniform Computer Information Transactions Act will not apply to these Terms. If a party initiates any proceeding regarding these Terms, the prevailing party to such proceeding is entitled to reasonable attorneys’ fees and costs.
+Each party shall comply with applicable data protection laws.
 
-- 16.3 You agree that Argos has the right to use your name and logo on the Site or other Argos websites or marketing materials, for the purposes of identifying you as a Argos customer and describing your use of the Services. You also agree that Argos may (but is under no obligation to): (i) issue a press release identifying you as a Argos customer; (ii) inform other potential customers that you are a user of the Services; and (iii) identify you as a customer in other forms of publicity (including, without limitation, case studies, blog posts, and the like.
+Argos implements appropriate technical and organizational measures designed to protect the security, confidentiality, and integrity of Customer Data.
 
-- 16.4 You may not assign these Terms, in whole or in part, by operation of law or otherwise, without the prior written consent of Argos, and any attempted transfer, assignment or delegation without such consent will be void and of no effect. Argos may freely transfer, assign or delegate these Terms, or its rights and duties under these Terms, without notice to you. Subject to the foregoing, these Terms will be binding upon and will inure to the benefit of the parties and their respective representatives, heirs, administrators, successors and permitted assigns.
+Where Argos processes personal data on behalf of Customer, Customer acts as controller and Argos acts as processor to the extent those concepts apply under applicable data protection law. That processing is governed by the Argos Data Processing Agreement, which Argos makes available on request and which is incorporated into these Terms where applicable data protection law requires such an agreement.
 
-- 16.5 Except as expressly set forth in these Terms, the exercise by either party of any of its remedies will be without prejudice to its other remedies under these Terms or otherwise. The failure by a party to enforce any part of these Terms will not constitute a waiver of future enforcement of that or any other provision. Any waiver of any provision of these Terms will be effective only if in writing and signed by an authorized representative of the waiving party.
+Argos uses third-party service providers and subprocessors to operate the Service. The current list is published in the [Argos privacy policy](/privacy).
 
-- 16.6 You agree that any notice that Argos is required to provide pursuant to these Terms can be given electronically, which may include an email to the email address you provide to Argos as part of your Registration Data. These notices can be about a wide variety of things, including responding to your questions, requests for additional information, and legal notices. You agree that such electronic notices satisfy any legal requirement that such communications be in writing. An electronic notice will be deemed to have been received on the day the email is sent to you, provided that the email is the same as the email address you provided as part of your Registration Data.
+Argos remains responsible for the performance of its subcontracted obligations and requires subprocessors that process Customer Data to be subject to appropriate confidentiality, security, and data protection obligations.
 
-- 16.7 You acknowledge that you are responsible for complying with all applicable laws and regulations associated with your access and use of the Site and Services, including, without limitation, all applicable export control laws and regulations.
+In the event of a personal data breach affecting Customer Data, Argos will notify Customer without undue delay after becoming aware of the breach. Shorter notification periods may be agreed in a separately executed written agreement.
 
-- 16.8 We do not develop any technical data or computer software pursuant to these Terms. The Site and the Services have been developed solely with private funds, are considered “Commercial Computer Software” and “Commercial Computer Software Documentation” as described in FAR 12.212, FAR 27.405-3, and DFARS 227.7202-3, and access is provided to U.S. Government end users as restricted computer software and limited rights data. Any use, disclosure, modification, distribution, or reproduction of the Site or the Services by the U.S. Government, its end users or contractors is subject to the restrictions set forth in these Terms.
+Additional information about how Argos processes personal information is available in the [Argos privacy policy](/privacy).
 
-- 16.9 If any portion of these Terms is held to be unenforceable or invalid, that portion will be enforced to the maximum extent possible, and all other provisions will remain in full force and effect.
+## 14. Data location
 
-- 16.10 Except for payments due under these Terms, neither party will be responsible for any delay or failure to perform that is attributable in whole or in part to any cause beyond its reasonable control, including, without limitation, acts of God (fire, storm, floods, earthquakes, etc.); civil disturbances; disruption of telecommunications, power or other essential services; interruption or termination of service by any service providers used by Argos to host the Services or to link its servers to the Internet; labor disturbances; vandalism; cable cut; computer viruses or other similar occurrences; or any malicious or unlawful acts of any third party.
+Argos hosts the Service on infrastructure operated by Amazon Web Services, located in the United States and in the European Union.
 
-- 16.11 We are each independent contractors with respect to the subject matter of these Terms. Nothing contained in these Terms will be deemed or construed in any manner whatsoever to create a partnership, joint venture, employment, agency, fiduciary, or other similar relationship between us, and neither of us can bind the other contractually.
+Where applicable law requires safeguards for international transfers of personal data, Argos will use a transfer mechanism recognized under that law.
+
+## 15. Data export and deletion
+
+Customer may access or export Customer Data through functionality made available by the Service.
+
+Following termination of an account or subscription, Argos will make Customer Data available for retrieval for thirty (30) days.
+
+Argos may subsequently delete Customer Data unless retention is required by law or reasonably necessary for legitimate legal, security, backup, or compliance purposes.
+
+Data stored in backups may remain until those backups expire in accordance with Argos's standard backup retention processes.
+
+## 16. Acceptable use
+
+Customer shall not use the Service to:
+
+- violate applicable law
+- infringe the intellectual property or other rights of third parties
+- distribute malware or malicious code
+- attempt to gain unauthorized access to the Service or related systems
+- interfere with the security, integrity, or performance of the Service
+- circumvent usage limits or security controls
+- use the Service in a manner reasonably likely to harm the Service or other customers
+- resell or sublicense access to the Service unless expressly authorized by Argos
+
+Customer shall not reverse engineer or attempt to derive the source code of proprietary components of the Service, except to the extent such a restriction is prohibited by applicable law.
+
+Nothing in this section restricts access to or use of software made available by Argos under an open source license, in accordance with that license.
+
+## 17. Beta and preview features
+
+Argos may make features available on a beta, preview, early access, or experimental basis.
+
+Those features are provided as is, are excluded from any availability commitment, warranty, indemnity, or support obligation, and may be changed or discontinued at any time.
+
+Argos will identify a feature as beta or preview where that is the case.
+
+## 18. Suspension
+
+Argos may suspend access to the Service where reasonably necessary because of:
+
+- non-payment of undisputed fees
+- misuse of the Service
+- a security risk affecting the Service or other customers
+- violation of these Terms
+- violation of applicable law
+
+Argos will use commercially reasonable efforts to provide prior notice where practicable.
+
+## 19. Argos intellectual property
+
+Argos and its licensors retain all rights, title, and interest in the Service and associated intellectual property.
+
+Except for the limited right to use the Service granted under these Terms, no intellectual property rights are transferred to Customer.
+
+The Argos name, logo, and other Argos trademarks may not be used without Argos's prior written consent. Third-party trademarks appearing in the Service belong to their respective owners, and their use denotes interoperability rather than any affiliation or endorsement.
+
+Open source components remain governed by their applicable open source licenses.
+
+Customer may provide suggestions, ideas, or feedback regarding the Service. Argos may use such feedback without restriction or obligation to Customer.
+
+## 20. Customer name and logo
+
+Unless Customer has notified Argos otherwise in writing, Customer grants Argos permission to identify Customer as a user of Argos and to use Customer's name and logo in customer lists, websites, presentations, and other marketing materials.
+
+Customer may revoke this permission at any time by notifying Argos in writing.
+
+Upon receiving such notice, Argos will stop future use of Customer's name and logo within a reasonable period.
+
+## 21. Support
+
+Argos provides support for paid plans through the support channels made available for the applicable plan.
+
+Unless a specific service level or response time has been expressly agreed in writing, Argos does not guarantee a particular support response or resolution time.
+
+Enterprise support and service levels may be defined in a separate Statement of Work or other written agreement.
+
+## 22. Service levels
+
+Unless a specific availability commitment has been expressly agreed in writing, Argos does not guarantee any particular level of availability.
+
+Argos will use commercially reasonable efforts to maintain the availability and performance of the Service.
+
+Any service credits or other remedies for failure to meet an agreed service level must be expressly provided in the applicable agreement.
+
+## 23. Warranties
+
+Argos warrants that it will provide paid Services with reasonable skill and care, in accordance with generally accepted industry standards. This is an obligation of means and not an obligation of result.
+
+Except as expressly provided in these Terms or another written agreement, the Service is provided “as is” and “as available”.
+
+**To the maximum extent permitted by applicable law, Argos disclaims all other warranties, whether express, implied, or statutory, including any implied warranty of merchantability, fitness for a particular purpose, or non-infringement.**
+
+## 24. Indemnification
+
+Argos will indemnify Customer against third-party claims alleging that the Service infringes third-party intellectual property rights.
+
+This obligation does not apply to claims arising from:
+
+- modifications not made by Argos
+- Customer Data
+- use of the Service contrary to these Terms or applicable documentation
+- use of the Service in combination with products or services not provided by Argos, where the claim would not otherwise have arisen
+- beta or preview features
+
+Customer will indemnify Argos against third-party claims arising from Customer's misuse of the Service, Customer Data, or violation of applicable law.
+
+## 25. Limitation of liability
+
+Neither party shall be liable to the other for indirect, incidental, special, exemplary, or consequential damages, or for loss of profits, revenues, goodwill, or business opportunities arising out of or relating to the Service, to the extent permitted by law.
+
+Argos's total cumulative liability arising out of or relating to these Terms or the Service shall not exceed the fees paid by Customer to Argos during the twelve (12) months preceding the event giving rise to the claim.
+
+For a free Service, Argos's total cumulative liability shall not exceed one hundred (100) euros.
+
+These limitations do not apply to Customer's obligation to pay fees due.
+
+Nothing in these Terms limits liability where such a limitation is prohibited by applicable law, including in cases of fraud, willful misconduct, or gross negligence.
+
+## 26. Termination
+
+Customer may stop using the Service at any time.
+
+Cancellation of a paid subscription is governed by Section 6.
+
+Argos may terminate these Terms or Customer's access to the Service if Customer materially breaches these Terms and fails to remedy that breach within thirty (30) days after notice, where the breach can be remedied.
+
+Argos may terminate access immediately where reasonably necessary to prevent fraud, unlawful activity, abuse, or material security risks.
+
+Upon termination, Customer's right to access and use the Service ends, subject to the data retrieval period described in Section 15.
+
+Sections that by their nature should survive termination will continue to apply, including provisions concerning confidentiality, intellectual property, fees owed, disclaimers, indemnification, and limitation of liability.
+
+## 27. Changes to the Service
+
+Argos may change the Service over time as the product evolves.
+
+For paid subscriptions, Argos will not intentionally make a material reduction to the core functionality of the subscribed Service during the current billing period without reasonable cause.
+
+This does not prevent Argos from making changes required for security, legal compliance, technical maintenance, or the protection of the Service or its users.
+
+## 28. Changes to these Terms
+
+Argos may update these Terms from time to time.
+
+Where a change materially affects the rights or obligations of customers with an active paid subscription, Argos will provide at least thirty (30) days' notice before the change takes effect. A customer that does not accept the change may terminate its subscription before the change takes effect and receive a pro rata refund of any prepaid fees covering the remainder of the then-current billing period.
+
+Changes required by law, regulation, security considerations, or to address an immediate risk may take effect sooner.
+
+Continued use of the Service after updated Terms become effective constitutes acceptance of the updated Terms.
+
+Changes to these Terms do not override a separately executed written agreement between Customer and Smooth Code SAS.
+
+## 29. Third-party services
+
+The Service may integrate with or rely on third-party products and services, including source code hosting, authentication, and messaging providers that Customer chooses to connect.
+
+Customer's use of third-party products may be subject to separate terms between Customer and the applicable third party.
+
+Argos is not responsible for third-party products that are not controlled by Argos.
+
+This section does not limit Argos's obligations regarding subprocessors performing services on Argos's behalf.
+
+## 30. Notices and communications
+
+Argos may give any notice required under these Terms electronically, including by email to the address associated with Customer's account or by a notice posted in the Service. Customer agrees that such electronic notices satisfy any requirement that a communication be in writing, and that a notice sent by email is deemed received on the day it is sent.
+
+Customer is responsible for keeping the email address associated with its account accurate and monitored.
+
+Customer may give notice to Argos at contact@argos-ci.com.
+
+Argos may send Customer transactional communications reasonably necessary to provide the Service, including account, billing, security, and operational notices.
+
+Marketing communications may be sent in accordance with applicable law and Customer's communication preferences.
+
+## 31. Export control and sanctions
+
+Customer is responsible for complying with all applicable export control, economic sanctions, and import laws and regulations in connection with its use of the Service.
+
+Customer represents that it is not located in, organized under the laws of, or ordinarily resident in a jurisdiction subject to comprehensive sanctions, and that it is not a party designated on any applicable restricted party list.
+
+## 32. Independent contractors
+
+The parties are independent contractors.
+
+Nothing in these Terms creates a partnership, joint venture, employment, fiduciary, or agency relationship between the parties.
+
+Neither party has authority to bind the other unless expressly authorized in writing.
+
+## 33. Assignment
+
+Customer may not assign these Terms without Argos's prior written consent, except in connection with a merger, reorganization, or sale of substantially all of Customer's assets or business to which these Terms relate.
+
+Argos may assign these Terms in connection with a merger, corporate reorganization, sale of substantially all of its assets, or transfer of the Argos business.
+
+## 34. Force majeure
+
+Neither party shall be liable for delay or failure to perform caused by circumstances beyond its reasonable control.
+
+This section does not excuse Customer's obligation to pay fees already due.
+
+## 35. Governing law and jurisdiction
+
+These Terms are governed by the laws of France, without regard to conflict of law principles.
+
+The courts of Paris, France shall have exclusive jurisdiction over disputes arising out of or relating to these Terms, except where mandatory applicable law provides otherwise.
+
+## 36. General
+
+If any provision of these Terms is found invalid or unenforceable, the remaining provisions remain in effect.
+
+A failure to enforce any provision does not constitute a waiver of that provision.
+
+These Terms, together with any documents expressly incorporated into them, constitute the agreement between Customer and Argos regarding the Service, unless the parties have entered into a separate written agreement governing the Service. Any purchase order or other Customer terms inconsistent with these Terms have no effect unless expressly accepted in writing by Argos.
+
+No amendment or waiver of a separately executed agreement is effective unless made in accordance with that agreement.
+
+## 37. Contact
+
+Questions regarding these Terms may be sent to:
+
+**Smooth Code SAS**  
+30 Boulevard de Sébastopol  
+75004 Paris  
+France
+
+**Email:** [contact@argos-ci.com](mailto:contact@argos-ci.com)


### PR DESCRIPTION
The terms in the repo were Sentry's 2017 ToS — Functional Software, Inc., California law, San Francisco courts, USD. The privacy policy came from the same import and still relied on the Privacy Shield, invalidated in 2020. Both are rewritten for Smooth Code SAS under French law, aligned with the enterprise MSA and with the providers we actually run on (AWS, Cloudflare, Vercel, Stripe, Resend, Sentry, Plausible).

Beyond the base draft, the terms add the late payment interest and 40 € recovery indemnity required by article L441-10, a professional-use-only clause, a notices clause, beta features, and export control. Breach notification is "without undue delay" here and stays at 48 h in negotiated MSAs, retention is aligned on the MSA's 30 days, and a material change now gives paid customers 30 days' notice and a pro rata refund — so the terms take effect on September 11 for existing paid subscriptions.

Two things to confirm before merge: the per-provider locations in the subprocessor list, and log retention, which I left unquantified. Still open, and out of scope here: a DPA satisfying article 28(3), which the terms reference as available on request.
