### PR TITLE
Push the terms effective date to September 15

### DIFF
--- a/app/markdown/terms.mdx
+++ b/app/markdown/terms.mdx
@@ -1,8 +1,8 @@
 # Terms of service
 
-Last updated: August 12, 2026.
+Last updated: August 13, 2026.
 
-These terms take effect immediately for new customers. For customers with an active paid subscription on August 12, 2026, they take effect on September 11, 2026.
+These terms take effect immediately for new customers. For customers with an active paid subscription on August 13, 2026, they take effect on September 15, 2026.
 
 These Terms of Service (“Terms”) govern access to and use of the Argos software as a service platform, websites, applications, APIs, and related services made available by Smooth Code SAS (“Argos”, “we”, “us”, or “our”).
 
@@ -370,9 +370,9 @@ No amendment or waiver of a separately executed agreement is effective unless ma
 
 Questions regarding these Terms may be sent to:
 
-**Smooth Code SAS**  
-30 Boulevard de Sébastopol  
-75004 Paris  
+**Smooth Code SAS**
+30 Boulevard de Sébastopol
+75004 Paris
 France
 
 **Email:** [contact@argos-ci.com](mailto:contact@argos-ci.com)


### PR DESCRIPTION
September 11 was exactly thirty days from publication, so any slippage in sending the notice email would have put the notice below the thirty days section 28 promises. September 15 leaves margin whichever date the period is counted from.

The cohort stays anchored to August 12, the publication date, so who the deferred date applies to is unchanged. Moving the effective date later only ever favours the customer.

`EFFECTIVE_DATE` in the notice script is updated to match in argos-ci/argos#2466.
