### PR TITLE
chore(changelog): use storybook.acme.com as the domain example

### DIFF
--- a/changelogs/2026-09-01__custom-domains/index.mdx
+++ b/changelogs/2026-09-01__custom-domains/index.mdx
@@ -18,7 +18,7 @@ A generated deployment URL is fine for a reviewer and awkward for everyone else.
 - **A status worth reading** — each domain says whether it is waiting on DNS, issuing a certificate, or live, and shows the exact record to create until it resolves.
 
 ```
-docs.example.com.  CNAME  cname.argos-ci.live.
+storybook.acme.com.  CNAME  cname.argos-ci.live.
 ```
 
 Root domains are the one wrinkle: most DNS providers refuse a `CNAME` on an apex, so use an `ALIAS` or `ANAME` record pointing at the same value, or point a subdomain at Argos instead.


### PR DESCRIPTION
Follow-up to #363, which is merged: the changelog's DNS example now reads `storybook.acme.com` instead of `docs.example.com`, matching the `storybook`/`acme` naming used across the docs. The same example is being applied to the docs page, the app's UI copy, and the social drafts.

Build verified with `SHOW_SCHEDULED_ARTICLES=true`; the entry prerenders with the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)