### PR TITLE
Rework the Stabilize illustrations on the home page

### DIFF
--- a/app/home/stabilize/features/FlakyIndicator.tsx
+++ b/app/home/stabilize/features/FlakyIndicator.tsx
@@ -1,61 +1,223 @@
-"use client";
-
 import clsx from "clsx";
-import { CheckIcon, WavesIcon } from "lucide-react";
+import { CheckIcon, MousePointer2Icon, WavesIcon } from "lucide-react";
 
+import { ApplicationSVG } from "@/components/ApplicationSVG";
+import { Badge } from "@/components/Badge";
 import { Card } from "@/components/Card";
 import { Chip } from "@/components/Chip";
+import { DotIndicator } from "@/components/DotIndicator";
+import { SmallTitle } from "@/components/Typography";
+
+const TOTAL_BUILDS = 28;
+
+/**
+ * The changed tests of a build under review. Each one carries the badge Argos
+ * computes from the auto-approved builds of the last 7 days: how many of them
+ * showed exactly this change. Two flakes, one real change, so the badge reads
+ * as a verdict per test rather than a decoration on the list.
+ */
+const CHANGES = [
+  {
+    file: "pricing.spec.ts",
+    title: "plan toggle",
+    device: "Desktop",
+    width: "1280px",
+    occurrences: 12,
+    noise: 0.2,
+    seed: 3,
+  },
+  {
+    file: "checkout.spec.ts",
+    title: "cart total",
+    device: "Desktop",
+    width: "1440px",
+    occurrences: 4,
+    noise: 0.35,
+    seed: 7,
+  },
+  {
+    file: "navigation.spec.ts",
+    title: "mobile menu",
+    device: "Mobile",
+    width: "480px",
+    occurrences: 0,
+    noise: 0,
+    seed: 1,
+  },
+  {
+    file: "settings.spec.ts",
+    title: "billing form",
+    device: "Tablet",
+    width: "1024px",
+    occurrences: 0,
+    noise: 0,
+    seed: 2,
+  },
+];
+
+/**
+ * The row whose badge is hovered, its tooltip open. The second one, so the
+ * tooltip hangs near the middle of the list rather than off its top corner.
+ */
+const HOVERED = CHANGES[1]!;
 
 export function FlakyIndicator() {
   return (
-    <div className="relative mx-auto flex w-full max-w-2xl flex-col gap-8 p-4 text-sm">
-      <div
+    <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center gap-3 p-4">
+      <Card
+        shadow="high"
+        // Room on the right for the tooltip, which hangs off the hovered
+        // badge; the card and that room are centered together.
         className={clsx(
-          "flex flex-col items-center gap-3 self-start",
-          "animate-fade-in motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+          "relative w-full max-w-108 md:mr-76",
+          "animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
         )}
       >
-        <Card
-          className={clsx(
-            "flex max-w-sm flex-col gap-2 p-3",
-            "animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
-          )}
-        >
-          <div className="flex items-center gap-1.5 font-medium">
-            <WavesIcon className="size-4 text-(--danger-10)" />
-            Test is flaky
-          </div>
-          <p>
-            <strong className="font-medium">4 / 28 auto-approved builds</strong>
-             showed exactly the same change in the last 7 days.
-          </p>
-        </Card>
-        <Chip icon={WavesIcon} variant="danger">
-          4 / 28
-        </Chip>
-      </div>
-      <div
+        <div className="flex items-center justify-between gap-3 border-b-[0.5px] px-3 py-2">
+          <SmallTitle className="min-w-0">
+            <DotIndicator variant="danger" />
+            <span className="truncate">{CHANGES.length} changed tests</span>
+          </SmallTitle>
+          <Badge className="shrink-0">Build #11136</Badge>
+        </div>
+        <ol className="flex flex-col divide-y-[0.5px] px-1.5 py-1">
+          {CHANGES.map((change, index) => (
+            <ChangeRow
+              key={change.title}
+              index={index}
+              hovered={change === HOVERED}
+              {...change}
+            />
+          ))}
+        </ol>
+      </Card>
+      {/* On phones the tooltip cannot hang off the list without leaving the
+          screen, so it follows the card instead. */}
+      <FlakyTooltip
+        occurrences={HOVERED.occurrences}
         className={clsx(
-          "hidden flex-col items-center gap-3 self-end sm:flex",
-          "animate-fade-in animate-delay-250 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+          "w-full max-w-108 md:hidden",
+          "animate-slide-up-fade animate-delay-500 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
         )}
-      >
-        <Card
-          className={clsx(
-            "flex max-w-sm flex-col gap-2 p-3",
-            "animate-slide-up-fade animate-delay-250 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
-          )}
-        >
-          <div className="flex items-center gap-1.5 font-medium">
-            <CheckIcon className="size-4 text-(--success-10)" />
-            Stable
-          </div>
-          <p>No changes in 28 auto-approved builds over the last 7 days.</p>
-        </Card>
-        <Chip icon={CheckIcon} variant="success">
-          Stable
-        </Chip>
-      </div>
+      />
     </div>
+  );
+}
+
+function ChangeRow(
+  props: (typeof CHANGES)[number] & {
+    index: number;
+    hovered: boolean;
+  },
+) {
+  const {
+    file,
+    title,
+    device,
+    width,
+    occurrences,
+    noise,
+    seed,
+    index,
+    hovered,
+  } = props;
+  const flaky = occurrences > 1;
+  return (
+    <li
+      className={clsx(
+        "flex items-center gap-3 rounded-lg px-2 py-2.5",
+        hovered && "bg-(--neutral-3)",
+        "animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+        {
+          0: "animate-delay-100",
+          1: "animate-delay-200",
+          2: "animate-delay-300",
+          3: "animate-delay-[400ms]",
+        }[index],
+      )}
+    >
+      <ApplicationSVG
+        withChanges
+        noise={noise}
+        noiseSeed={seed}
+        className="h-12 w-auto shrink-0 rounded border-[0.5px]"
+      />
+      <div className="min-w-0 flex-1">
+        {/* On phones the file and the viewport width would push both lines
+            into an ellipsis; the title and the device still name the test. */}
+        <div className="truncate text-xs font-medium">
+          <span className="max-sm:hidden">{file} › </span>
+          {title}
+        </div>
+        <div className="mt-0.5 truncate text-xxs text-low">
+          {device}
+          <span className="max-sm:hidden"> · {width}</span>
+        </div>
+      </div>
+      <span className="relative shrink-0">
+        <Chip
+          icon={flaky ? WavesIcon : CheckIcon}
+          variant={flaky ? "danger" : "success"}
+          className="text-xs"
+        >
+          {flaky ? `${occurrences} / ${TOTAL_BUILDS}` : "Stable"}
+        </Chip>
+        {hovered ? (
+          <>
+            <MousePointer2Icon
+              className={clsx(
+                "absolute -right-1.5 -bottom-2 size-4 fill-(--neutral-12) text-(--neutral-1)",
+                "animate-fade-in animate-delay-500 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+              )}
+              strokeWidth={1.5}
+              aria-hidden="true"
+            />
+            <FlakyTooltip
+              occurrences={occurrences}
+              caret
+              className={clsx(
+                "absolute top-1/2 left-full z-10 ml-5 hidden w-68 -translate-y-1/2 md:block",
+                "animate-fade-in animate-delay-500 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+              )}
+            />
+          </>
+        ) : null}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * What hovering the badge shows: the same sentence Argos uses, with the
+ * numbers the badge abbreviates.
+ */
+function FlakyTooltip(props: {
+  occurrences: number;
+  caret?: boolean;
+  className?: string;
+}) {
+  const { occurrences, caret, className } = props;
+  return (
+    <Card
+      shadow="high"
+      className={clsx("flex flex-col gap-1.5 p-3 text-xs", className)}
+    >
+      {caret ? (
+        <span
+          className="absolute top-1/2 -left-1 size-2 -translate-y-1/2 rotate-45 border-b-[0.5px] border-l-[0.5px] bg-app"
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="flex items-center gap-1.5 font-medium">
+        <WavesIcon className="size-3.5 text-(--danger-10)" />
+        Test is flaky
+      </div>
+      <p className="text-low">
+        <strong className="font-medium text-default">
+          {occurrences} / {TOTAL_BUILDS} auto-approved builds
+        </strong>{" "}
+        showed exactly the same change in the last 7 days.
+      </p>
+    </Card>
   );
 }

--- a/app/home/stabilize/features/IgnoreChanges.tsx
+++ b/app/home/stabilize/features/IgnoreChanges.tsx
@@ -16,24 +16,32 @@ import { ContainedIcon } from "@/components/ContainedIcon";
 import { DotIndicator } from "@/components/DotIndicator";
 import { SmallTitle } from "@/components/Typography";
 
+/**
+ * The flow reads left to right on wider screens: the flaky build, the ignore
+ * action, the next build. On phones the two builds stack, one above the
+ * other, with the action as a pill on a vertical line between them; side by
+ * side they were too narrow for their own headers.
+ */
 export function IgnoreChanges() {
   return (
-    <div className="relative flex w-full max-w-4xl items-center gap-10 p-5">
-      <Line
+    <div className="relative flex w-full max-w-4xl flex-col items-center gap-6 p-5 sm:flex-row sm:gap-10">
+      <FlowLine
         className={clsx(
-          // On phones the middle card is hidden, so the line only spans the
-          // two remaining cards instead of peeking out past them.
-          "absolute left-1/2 z-0 size-75 -translate-x-1/2 max-sm:w-[calc(100%-2.5rem)]",
+          "absolute left-1/2 z-0 hidden size-75 -translate-x-1/2 sm:block",
+          "animate-fade-in animate-delay-300 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+        )}
+      />
+      {/* An explicit height: an absolutely positioned svg keeps its intrinsic
+          150px rather than stretching between top and bottom. */}
+      <FlowLine
+        vertical
+        className={clsx(
+          "absolute top-5 left-1/2 z-0 h-[calc(100%-2.5rem)] w-2 -translate-x-1/2 sm:hidden",
           "animate-fade-in animate-delay-300 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
         )}
       />
 
-      <Card
-        className={clsx(
-          "relative flex flex-1 flex-col gap-3 p-3",
-          "animate-slide-up-fade motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
-        )}
-      >
+      <BuildCard className="animate-slide-up-fade animate-duration-500 fill-mode-both motion-reduce:animate-fade-in">
         <Header>
           <SmallTitle>
             <ContainedIcon variant="danger" icon={AlertTriangleIcon} />
@@ -45,7 +53,15 @@ export function IgnoreChanges() {
         </Header>
 
         <ApplicationSVG withChanges />
-      </Card>
+      </BuildCard>
+
+      {/* Phones: the action alone, on the line between the two builds. */}
+      <IgnorePill
+        className={clsx(
+          "relative z-10 sm:hidden",
+          "animate-slide-up-fade animate-delay-100 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
+        )}
+      />
 
       <Card
         className={clsx(
@@ -54,19 +70,11 @@ export function IgnoreChanges() {
         )}
       >
         <IgnoreAction />
-        <div className="shadow-xxs pointer-events-none absolute -bottom-5 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border bg-app px-2 py-1 text-xs whitespace-nowrap text-(--neutral-12)">
-          <MousePointerClickIcon
-            className="size-4 text-(--primary-9)"
-            aria-hidden="true"
-            strokeWidth={1}
-          />
-          Ignore changes
-        </div>
+        <IgnorePill className="pointer-events-none absolute -bottom-5 left-1/2 -translate-x-1/2" />
       </Card>
 
-      <Card
+      <BuildCard
         className={clsx(
-          "relative flex flex-1 flex-col gap-3 p-3",
           "animate-slide-up-fade animate-delay-200 motion-reduce:animate-fade-in animate-duration-500 fill-mode-both",
         )}
       >
@@ -75,9 +83,13 @@ export function IgnoreChanges() {
             <ContainedIcon variant="success" icon={CheckIcon} />
             Next build
           </SmallTitle>
-          <Badge>
+          {/* The narrow phone card has no room for the full label next to
+              the title; "No changes" and the green dot say the same. */}
+          <Badge className="shrink-0 whitespace-nowrap">
             <DotIndicator variant="success" />
-            No changes detected
+            <span>
+              No changes<span className="max-sm:hidden"> detected</span>
+            </span>
           </Badge>
         </Header>
 
@@ -91,8 +103,24 @@ export function IgnoreChanges() {
             </Badge>
           </div>
         </div>
-      </Card>
+      </BuildCard>
     </div>
+  );
+}
+
+/**
+ * Narrow and centered on phones, so the stack stays short; a full column of
+ * the row above that.
+ */
+function BuildCard(props: ComponentPropsWithRef<"div">) {
+  return (
+    <Card
+      {...props}
+      className={clsx(
+        "relative flex w-full max-w-64 flex-col gap-3 p-3 sm:max-w-none sm:flex-1",
+        props.className,
+      )}
+    />
   );
 }
 
@@ -101,10 +129,29 @@ function Header(props: ComponentPropsWithRef<"div">) {
     <div
       {...props}
       className={clsx(
-        "flex flex-col items-center justify-between gap-3 sm:flex-row",
+        "flex items-center justify-between gap-3",
         props.className,
       )}
     />
+  );
+}
+
+function IgnorePill(props: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        "shadow-xxs flex items-center gap-1 rounded-full border bg-app px-2 py-1 text-xs whitespace-nowrap text-(--neutral-12)",
+        props.className,
+      )}
+    >
+      <MousePointerClickIcon
+        className="size-4 text-(--primary-9)"
+        aria-hidden="true"
+        strokeWidth={1}
+      />
+      Ignore changes
+    </div>
   );
 }
 
@@ -123,17 +170,26 @@ function IgnoreAction(props: ComponentPropsWithoutRef<"div">) {
   );
 }
 
-function Line(props: ComponentPropsWithoutRef<"svg">) {
+/**
+ * The dashed line the flow runs along, its dashes drifting from the flaky
+ * build toward the next one. Drawn in percentages of its box so the same
+ * element serves the row and the stack.
+ */
+function FlowLine(
+  props: ComponentPropsWithoutRef<"svg"> & { vertical?: boolean },
+) {
+  const { vertical = false, ...rest } = props;
   return (
     <svg
-      {...props}
-      viewBox="0 0 300 300"
-      className={clsx("pointer-events-none", props.className)}
+      {...rest}
+      className={clsx("pointer-events-none", rest.className)}
       aria-hidden="true"
     >
-      <path
-        d="M 0 150 C 180 150 205 150 300 150"
-        fill="none"
+      <line
+        x1={vertical ? "50%" : "0"}
+        y1={vertical ? "0" : "50%"}
+        x2={vertical ? "50%" : "100%"}
+        y2={vertical ? "100%" : "50%"}
         stroke="var(--primary-8)"
         strokeWidth="1"
         strokeLinecap="round"
@@ -147,7 +203,7 @@ function Line(props: ComponentPropsWithoutRef<"svg">) {
           dur="1.25s"
           repeatCount="indefinite"
         />
-      </path>
+      </line>
     </svg>
   );
 }

--- a/app/home/stabilize/features/PlaywrightTrace.tsx
+++ b/app/home/stabilize/features/PlaywrightTrace.tsx
@@ -84,7 +84,10 @@ export function PlaywrightTrace() {
           </Badge>
         </div>
 
-        <div className="hidden space-y-2 md:block">
+        {/* Phones: the steps are the story once the viewer is gone. Between
+            sm and md the viewer sits beside the card, and the steps would
+            make it twice as tall. */}
+        <div className="hidden space-y-2 max-sm:block md:block">
           {events.map((event) => (
             <TraceEvent key={event.label} {...event} />
           ))}


### PR DESCRIPTION
The three illustrations of the home Stabilize carousel, reworked from Jeremy's review.

## A flaky badge on every change

The panel was two tooltip cards floating on their own, with a chip under each. No build, no change, nothing of the product around the badge: it was the weakest panel next to "Ignore noise, keep signal" and "Debug from the trace".

`app/home/stabilize/features/FlakyIndicator.tsx` now shows what the docs describe (spot the badge beside each changed test, hover it for the numbers, select it to open the test page):

- a build review card: "4 changed tests", the build number, then four changed tests with their diff thumbnail and their badge (12 / 28, 4 / 28, Stable, Stable);
- the second row is hovered: highlighted, a cursor on the badge, and the "Test is flaky" tooltip hanging off it with a caret. The tooltip copy is unchanged;
- on phones the tooltip follows the card instead of leaving the screen, and the file prefix and viewport width of each row are hidden so nothing truncates.

Same building blocks as the neighbouring panels: `Card`, `Chip`, `Badge`, `ApplicationSVG`, staggered entry animations. The `/stabilize` page keeps its own smaller `FlakyIndicatorScreenshotIllustration`.

## Ignore noise, keep signal, on phones

Side by side on a phone, the two build cards were too narrow for their own headers: titles and badges wrapped on two or three lines. In `app/home/stabilize/features/IgnoreChanges.tsx` the two builds now stack on phones, centered and a little narrower, with the "Ignore changes" pill on a vertical dashed line between them. The middle icon card stays on md and up, headers are one row at every width, and the badge reads "No changes" on phones. Nothing changes from 640px up.

## Debug from the trace, on phones

On a phone the card was a title, two badges and a button: the steps were hidden below md and the trace viewer below sm. In `app/home/stabilize/features/PlaywrightTrace.tsx` the three steps now show on phones, where the viewer is gone: two green steps, the red failed assertion, and the Run Trace button under them. Between sm and md they stay hidden, since the viewer sits beside the card there.

## Checks

- Light and dark, 375 / 700 / 800 / 1280 px in the dev server.
- `oxfmt`, `oxlint`, `tsc --noEmit`, `knip` clean. No copy change, so no markdown twin to update.
- The Argos build will show the home Stabilize panel diffs; that is the expected change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
